### PR TITLE
Fixed Issue#31

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ sim:
 	rm -f ${WALLY}/sim/questa/fcov_ucdb/*
 	wsim rv32gc ${WALLY}/addins/cvw-arch-verif/tests/rv32/I/WALLY-COV-add.elf --fcov
 	wsim rv32gc ${WALLY}/addins/cvw-arch-verif/tests/rv32/I/WALLY-COV-addi.elf --fcov
-	#wsim rv32gc ${WALLY}/addins/cvw-arch-verif/tests/rv32/I/WALLY-COV-lw.elf --fcov
-	#wsim rv32gc ${WALLY}/addins/cvw-arch-verif/tests/rv32/I/WALLY-COV-sw.elf --fcov
-	#wsim rv32gc ${WALLY}/addins/cvw-arch-verif/tests/rv32/I/WALLY-COV-beq.elf --fcov
-	#wsim rv32gc ${WALLY}/addins/cvw-arch-verif/tests/rv32/I/WALLY-COV-auipc.elf --fcov
-	#wsim rv32gc ${WALLY}/addins/cvw-arch-verif/tests/rv32/I/WALLY-COV-lui.elf --fcov
-	#wsim rv64gc ${WALLY}/addins/cvw-arch-verif/tests/rv64/I/WALLY-COV-add.elf --fcov
-	#wsim rv64gc ${WALLY}/addins/cvw-arch-verif/tests/rv64/I/WALLY-COV-addi.elf --fcov
+	wsim rv32gc ${WALLY}/addins/cvw-arch-verif/tests/rv32/I/WALLY-COV-lw.elf --fcov
+	wsim rv32gc ${WALLY}/addins/cvw-arch-verif/tests/rv32/I/WALLY-COV-sw.elf --fcov
+	wsim rv32gc ${WALLY}/addins/cvw-arch-verif/tests/rv32/I/WALLY-COV-beq.elf --fcov
+	wsim rv32gc ${WALLY}/addins/cvw-arch-verif/tests/rv32/I/WALLY-COV-auipc.elf --fcov
+	wsim rv32gc ${WALLY}/addins/cvw-arch-verif/tests/rv32/I/WALLY-COV-lui.elf --fcov
+	wsim rv64gc ${WALLY}/addins/cvw-arch-verif/tests/rv64/I/WALLY-COV-add.elf --fcov
+	wsim rv64gc ${WALLY}/addins/cvw-arch-verif/tests/rv64/I/WALLY-COV-addi.elf --fcov
 	make merge
 
 merge:

--- a/templates/cr_rs1_imm_corners.txt
+++ b/templates/cr_rs1_imm_corners.txt
@@ -1,16 +1,16 @@
-    cp_imm12_corners : coverpoint unsigned'(ins.current.imm)  iff (ins.trap == 0 )  {
+    cp_imm12_corners : coverpoint signed'(ins.current.imm)  iff (ins.trap == 0 )  {
         option.comment = "Imm Corners";
-        wildcard bins zero  = {12'b000000000000};
-        wildcard bins one   = {12'b000000000001};
-        wildcard bins two   = {12'b000000000010};
-        wildcard bins hm1   = {12'b001111111111};
-        wildcard bins h   =   {12'b010000000000};
-        wildcard bins max   = {12'b011111111111};
-        wildcard bins min   = {12'b100000000000};
-        wildcard bins minp1 = {12'b100000000001};
-        wildcard bins onesm1 = {12'b111111111110};
-        wildcard bins ones  = {12'b111111111111};
+        wildcard bins zero  = {0};
+        wildcard bins one   = {1};
+        wildcard bins two   = {2};
+        wildcard bins hm1   = {1023};
+        wildcard bins h   =   {1024};
+        wildcard bins max   = {2047};
+        wildcard bins min   = {-2048};
+        wildcard bins minp1 = {-2047};
+        wildcard bins onesm1 = {-2};
+        wildcard bins ones  = {-1};
     }
-    cr_rs1_imm_corners: cross cp_rs1_corners,cp_imm12_corners  iff (ins.trap == 0 )  {
+    cr_rs1_imm_corners : cross cp_rs1_corners,cp_imm12_corners  iff (ins.trap == 0 )  {
         option.comment = "Cross coverage of RS1 sign and Imm corners";
     }


### PR DESCRIPTION
Fixed issue#31 in addi, now bins with negative values are being hit. The tests for cr_rs1_imm_corners were not being generated due to an issue in its template. It is also fixed.

The coverage of addi is now 97.33% which initially was 75.06%.