### PR TITLE
Achieved 100% coverage of RV32 add

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,16 +49,19 @@ build: $(OBJECTS)
 
 %.elf.objdump: %.elf
 
+# Some instructions get silently converted to 16-bit, this allows only Zc* instr to get converted to 16-bit 
+CMPR_FLAG = $(if $(findstring /Zc, $(dir $<)),c,)
+
 # Change many things if bit width isn't 64
 $(SRCDIR64)/%.elf: $(SRCDIR64)/%.$(SEXT) 
-	riscv64-unknown-elf-gcc -g -o $@ -march=rv64gqc_zfa_zba_zbb_zbc_zbs_zfh_zicboz_zicbop_zicbom_zicond -mabi=lp64 -mcmodel=medany \
+	riscv64-unknown-elf-gcc -g -o $@ -march=rv64gq$(CMPR_FLAG)_zfa_zba_zbb_zbc_zbs_zfh_zicboz_zicbop_zicbom_zicond -mabi=lp64 -mcmodel=medany \
 	    -nostartfiles -T${WALLY}/examples/link/link.ld $<
 	riscv64-unknown-elf-objdump -S -D $@ > $@.objdump
 	riscv64-unknown-elf-elf2hex --bit-width 64 --input $@ --output $@.memfile
 	extractFunctionRadix.sh $@.objdump
 
 $(SRCDIR32)/%.elf: $(SRCDIR32)/%.$(SEXT) 
-	riscv64-unknown-elf-gcc -g -o $@ -march=rv32gqc_zfa_zba_zbb_zbc_zbs_zfh_zicboz_zicbop_zicbom_zicond -mabi=ilp32 -mcmodel=medany \
+	riscv64-unknown-elf-gcc -g -o $@ -march=rv32gq$(CMPR_FLAG)_zfa_zba_zbb_zbc_zbs_zfh_zicboz_zicbop_zicbom_zicond -mabi=ilp32 -mcmodel=medany \
 	    -nostartfiles -T${WALLY}/examples/link/link.ld $<
 	riscv64-unknown-elf-objdump -S -D $@ > $@.objdump
 	riscv64-unknown-elf-elf2hex --bit-width 32 --input $@ --output $@.memfile

--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -285,6 +285,8 @@ def make_cr_rs1_rs2_corners(test, xlen):
   for v1 in corners:
     for v2 in corners:
       [rs1, rs2, rd, rs1val, rs2val, immval, rdval] = randomize()
+      while rs1 == rs2:
+        [rs1, rs2, rd, rs1val, rs2val, immval, rdval] = randomize()
       desc = "cr_rs1_rs2_corners (Test source rs1 = " + hex(v1) + " rs2 = " + hex(v2) + ")"
       writeCovVector(desc, rs1, rs2, rd, v1, v2, immval, rdval, test, xlen)
 


### PR DESCRIPTION
Modified **Makefile** to allow only Zc* extensions to get converted to 16-bit compressed instruction.

Found another bug which was preventing bins from being hit in cr_rs1_rs2_corners. Same register was used for both rs1 and rs2. For example:
`bin <min, max>`
rs1 is supposed to have minimum value (0x80000000) while rs2 maximum value (0x7fffffff). If rs1 and rs2 is the same register, it can't have both min and max simultaneously. 
Added few lines in testgen.py which prevents rs1 and rs2 being the same in cr_rs1_rs2_corners.