### PR TITLE
Fixed cp_asm_count for compressed instructions

### DIFF
--- a/bin/covergroupgen.py
+++ b/bin/covergroupgen.py
@@ -84,7 +84,11 @@ def customizeTemplate(covergroupTemplates, name, arch, instr):
         return ""
     instr_nodot = instr.replace(".", "_")
     template = template.replace("INSTRNODOT", instr_nodot)
-    template = template.replace("INSTR", instr)
+    # This cond is added so that compressed instrs without "c." can also be detected by cp_asm_count
+    if (name == "cp_asm_count" and instr.startswith("c.")):
+        template = template.replace("INSTR", f'{instr[2:]}" || ins.ins_str == "{instr}')
+    else:
+        template = template.replace("INSTR", instr)
     template = template.replace("ARCHUPPER", arch.upper())
     template = template.replace("ARCHCASE", arch)
     template = template.replace("ARCH", arch.lower())

--- a/bin/covergroupgen.py
+++ b/bin/covergroupgen.py
@@ -84,9 +84,9 @@ def customizeTemplate(covergroupTemplates, name, arch, instr):
         return ""
     instr_nodot = instr.replace(".", "_")
     template = template.replace("INSTRNODOT", instr_nodot)
-    # This cond is added so that compressed instrs without "c." can also be detected by cp_asm_count
+    # This cond is added to neglect "c." from compressed instructions
     if (name == "cp_asm_count" and instr.startswith("c.")):
-        template = template.replace("INSTR", f'{instr[2:]}" || ins.ins_str == "{instr}')
+        template = template.replace("INSTR", instr[2:])
     else:
         template = template.replace("INSTR", instr)
     template = template.replace("ARCHUPPER", arch.upper())

--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -625,6 +625,9 @@ def getcovergroups(coverdefdir, coverfiles):
 #        if (curinstr != ""):
 #          print(curinstr + ": " + str(coverpoints[curinstr]))
         curinstr = m.group(1)
+        #  If in a Zc* dir, add a preceding "c." to curinstr. (e.g. addi -> c.addi)
+        if (re.search(r'/RV..Zc.+_coverage', coverfile)):
+          curinstr = "c." + curinstr
         coverpoints[curinstr] = []
       m = re.search("\s*(\S+) :", line)
       if (m):


### PR DESCRIPTION
```
cp_asm_count : coverpoint ins.ins_str == "c.li"  iff (ins.trap == 0 )  {
        option.comment = "Number of times instruction is executed";
        bins count[]  = {1};
    }
```

By changing "c.li" to "li", the bin was getting hit. But this modification was leading to errors because testgen.py uses this to recognize an instruction to generate its tests. This was fixed by 

```
cp_asm_count : coverpoint ins.ins_str == "li" || ins.ins_str == "c.li"  iff (ins.trap == 0 )  {
        option.comment = "Number of times instruction is executed";
        bins count[]  = {1};
    }
```

This made the bin hit and testgen.py correctly recognized "c.li" as the instruction.