### PR TITLE
improved cp_asm_count for compressed instructions

### DIFF
--- a/bin/covergroupgen.py
+++ b/bin/covergroupgen.py
@@ -84,9 +84,14 @@ def customizeTemplate(covergroupTemplates, name, arch, instr):
         return ""
     instr_nodot = instr.replace(".", "_")
     template = template.replace("INSTRNODOT", instr_nodot)
-    # This cond is added to neglect "c." from compressed instructions
+    # Compressed instrs get passed to covergroups as 'c.li' -> 'li', 'c.addi16sp' -> 'addi'.
+    # This makes sure that cp_asm_count gets hit
+    c_instr_alias = {"c.addi16sp":"addi", "c.addi4spn":"addi"}
     if (name == "cp_asm_count" and instr.startswith("c.")):
-        template = template.replace("INSTR", instr[2:])
+        if (instr in c_instr_alias):
+            template = template.replace("INSTR", c_instr_alias[instr])
+        else:
+            template = template.replace("INSTR", instr[2:]) # Just strip 'c.'
     else:
         template = template.replace("INSTR", instr)
     template = template.replace("ARCHUPPER", arch.upper())

--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -619,19 +619,21 @@ def getcovergroups(coverdefdir, coverfiles):
   for coverfile in coverfiles:
     coverfile = coverdefdir + "/" + coverfile + "_coverage.svh"
     f = open(coverfile, "r")
+    prev_line = "" 
     for line in f:
       m = re.search(r'cp_asm_count.*\"(.*)"', line)
       if (m):
 #        if (curinstr != ""):
 #          print(curinstr + ": " + str(coverpoints[curinstr]))
         curinstr = m.group(1)
-        #  If in a Zc* dir, add a preceding "c." to curinstr. (e.g. addi -> c.addi)
+        #  If in a Zc* dir, curinstr name is on previous line
         if (re.search(r'/RV..Zc.+_coverage', coverfile)):
-          curinstr = "c." + curinstr
+          curinstr = re.search(r'option.comment = "(.*)"', prev_line).group(1)
         coverpoints[curinstr] = []
       m = re.search("\s*(\S+) :", line)
       if (m):
         coverpoints[curinstr].append(m.group(1))
+      prev_line = line # Store for next iteration
     f.close()
     print(coverpoints)
     return coverpoints


### PR DESCRIPTION
@davidharrishmc Thank you for pointing out that cp_asm_count for c.addi16sp and c.addi4spn are not being hit. 
I have added a dictionary in covergroupgen.py which handles all special cases like c.addi16sp, etc. We can add all special instructions in that dictionary and strip **'c.'** for other compressed instructions.
As for testgen.py, I have changed my approach to grab the compressed instruction's real name. 
```
    option.comment = "c.addi4spn";
    cp_asm_count : coverpoint ins.ins_str == "addi"  iff (ins.trap == 0 )  {
        option.comment = "Number of times instruction is executed";
        bins count[]  = {1};
    }
```
**curinstr** was being fetched from the cp_asm_count line. I have adjusted the code such that if we are in a Zc* directory, we will fetch the instruction name from the previous line (from option.comment). This is a more general approach as compared to adding a **'c.'** before every instruction.

If you have any suggestion, let me know.
