### PR TITLE
removed dz and uf flags for fadd

### DIFF
--- a/templates/cp_csr_fflags_ndz_nuf.txt
+++ b/templates/cp_csr_fflags_ndz_nuf.txt
@@ -1,0 +1,6 @@
+    cp_csr_fflags_ndz_nuf : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "fcsr", "fflags") iff (ins.trap == 0 )  {
+        option.comment = "Value of FCSR.fflags";
+        wildcard bins NX  = {5'b????1};
+        wildcard bins OF  = {5'b??1??};
+        wildcard bins NV  = {5'b1????};
+    }

--- a/testplans/RV32F.csv
+++ b/testplans/RV32F.csv
@@ -1,6 +1,6 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_fpr_hazard,cp_rd_corners,cp_rs1_corners,cp_rs2_corners,cr_rs1_rs2_corners,cmp_fd_fs1,cmp_fd_fs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2_sign,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rs1p,cp_fdp,cp_fs2p,cr_rs1_imm_corners,cp_bs,cp_rnum,cp_sc,cbo***,cp_csr_fflags,cp_csr_frm,cp_fs1_corners,cp_fs2_corners,cp_fs3_corners,cp_frm,cr_fs1_fs2_frm_corners,cr_fs1_fs3_frm_corners,cp_fclass,cp_fd,cp_fs1,cp_fs2,cp_fmemhazard,cp_fd_toggle
 flw,FL,x,,nx0,,,,,,,,,,,,,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,x,,,x,x
-fadd.s,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,x,x,,x,x,,,x,x,x,,
+fadd.s,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,ndz_nuf,x,x,x,,x,x,,,x,x,x,,
 fsw,FS,x,,nx0,,,,,,,,,,,,,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,x,,,,,,,,x,,
 fmadd.s,FR4,x,,,,,,,,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,x,x,x,x,x,x,,x,x,x,,
 fcvt.w.s,F2X,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,x,,,x,,,,,x,,,


### PR DESCRIPTION
Thought through this change and discussed with Prof. Harris, neither of these flags can be hit with `fadd` so  I created a new coverpoint with both of them excluded