### PR TITLE
Revert "100% coverage on fadd.s and fsub.s"

### DIFF
--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -60,7 +60,7 @@ def unsignedImm10(imm):
     imm = 16
   return str(imm)
 
-def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=None, rs3val=None, frm=""):
+def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=None, rs3val=None):
   lines = "\n# Testcase " + str(desc) + "\n"
   if (rs1val < 0):
     rs1val = rs1val + 2**xlen
@@ -79,7 +79,7 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
     lines = lines + "li x4, " + formatstr.format(rs2val) + " # prep fs2\n"
     lines = lines + "sw x4, 0(x2) # store fs2 value in memory\n"
     lines = lines + "flw f" + str(rs2) + ", 0(x2) # load fs2 value from memory\n"
-    lines = lines + f"{test} f{rd}, f{rs1}, f{rs2}" + (f", {frm}" if frm else "") + " # perform operation\n"
+    lines = lines + test + " f" + str(rd) + ", f" + str(rs1) + ", f" + str(rs2) + " # perform operation\n" 
   elif (test in citype):
     if(test == "c.lui" and rd ==2): # rd ==2 is illegal operand 
       rd = 9 # change to arbitrary other register
@@ -511,7 +511,7 @@ def make_fd_fs2(test, xlen):
     desc = "cmp_fd_fs2 (Test fd = fs2 = f" + str(r) + ")"
     writeCovVector(desc, rs1, r, r, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
-def make_cr_fs1_fs2_corners(test, xlen, frm = False):
+def make_cr_fs1_fs2_corners(test, xlen):
   for v1 in fcorners:
     for v2 in fcorners:
       # select distinct fs1 and fs2
@@ -519,30 +519,11 @@ def make_cr_fs1_fs2_corners(test, xlen, frm = False):
       while rs1 == rs2:
         [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
       desc = "cr_fs1_fs2_corners (Test source fs1 = " + hex(v1) + " fs2 = " + hex(v2) + ")"
-      if frm:
-        roundingModes = ["rdn", "rmm", "rne", "rtz", "rup"]
-        for mode in roundingModes:
-          writeCovVector(desc, rs1, rs2, rd, v1, v2, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val, frm = mode)
-        
-        # Change the csr and hit the corner cases for dynamic rounding modes
-        for csrMode in ["0x0", "0x1", "0x2", "0x3", "0x4"]:
-          lines = f"\n # set fcsr.frm to {csrMode} \n"
-          lines = lines + f"fsrmi {csrMode}\n"
-          f.write(lines)
-          writeCovVector(desc, rs1, rs2, rd, v1, v2, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val, frm = "dyn")
-        
-        # Reset the csr to default value
-        lines = f"\n # reset fcsr.frm to RNE \n"
-        lines = lines + f"fsrmi 0x0\n"
-        f.write(lines)
-      else:
-        writeCovVector(desc, rs1, rs2, rd, v1, v2, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
+      writeCovVector(desc, rs1, rs2, rd, v1, v2, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
 def make_fs1_corners(test, xlen):
   for v in fcorners:
     [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
-    while rs2 == rs1:
-      rs2 = randint(1, 31)
     desc = "cp_fs1_corners (Test source fs1 value = " + hex(v) + ")"
     writeCovVector(desc, rs1, rs2, rd, v, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
@@ -551,7 +532,6 @@ def make_fs2_corners(test, xlen):
     [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
     desc = "cp_fs2_corners (Test source fs2 value = " + hex(v) + ")"
     writeCovVector(desc, rs1, rs2, rd, rs1val, v, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
-  
 
 def write_tests(coverpoints, test, xlen):
   for coverpoint in coverpoints:
@@ -687,8 +667,6 @@ def write_tests(coverpoints, test, xlen):
       make_fs2_corners(test, xlen)
     elif (coverpoint == "cr_fs1_fs2_corners"):
       make_cr_fs1_fs2_corners(test, xlen)
-    elif (coverpoint == "cr_fs1_fs2_corners_frm"):
-      make_cr_fs1_fs2_corners(test, xlen, frm = True)
     else:
       print("Warning: " + coverpoint + " not implemented yet for " + test)
       

--- a/templates/cr_fs1_fs2_corners_frm.txt
+++ b/templates/cr_fs1_fs2_corners_frm.txt
@@ -1,3 +1,3 @@
-    cr_fs1_fs2_corners_frm : cross cp_fs1_corners,cp_fs2_corners,cp_frm  iff (ins.trap == 0 )  {
+    cr_fs1_fs2_corners_frm : cross cp_fs1_corners,cp_fs2_corners,cp_csr_frm  iff (ins.trap == 0 )  {
         option.comment = "Cross coverage FS1, FS2, rounding mode";
     }

--- a/testplans/RV32F.csv
+++ b/testplans/RV32F.csv
@@ -1,7 +1,6 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_fpr_hazard,cp_rd_corners,cp_rs1_corners,cp_rs2_corners,cr_rs1_rs2_corners,cmp_fd_fs1,cmp_fd_fs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2_sign,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rs1p,cp_fdp,cp_fs2p,cr_rs1_imm_corners,cp_bs,cp_rnum,cp_sc,cbo***,cp_csr_fflags,cp_csr_frm,cp_fs1_corners,cp_fs2_corners,cp_fs3_corners,cp_frm,cr_fs1_fs2_corners,cr_fs1_fs3_frm_corners,cp_fclass,cp_fd,cp_fs1,cp_fs2,cp_fmemhazard,cp_fd_toggle
 flw,FL,x,,nx0,,,,,,,,,,,,,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,x,,,x,x
 fadd.s,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,ndz_nuf,x,x,x,,x,frm,,,x,x,x,,
-fsub.s,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,ndz_nuf,x,x,x,,x,frm,,,x,x,x,,
 fsw,FS,x,,nx0,,,,,,,,,,,,,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,x,,,,,,,,x,,
 fmadd.s,FR4,x,,,,,,,,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,x,x,x,x,frm,x,,x,x,x,,
 fcvt.w.s,F2X,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,x,,,x,,,,,x,,,
@@ -10,6 +9,7 @@ fmv.x.w,F2X,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,,,,,,,x,,,
 fmsub.s,FR4,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,x,x,x,x,frm,x,,x,x,x,,,
 fnmsub.s,FR4,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,x,x,x,x,frm,x,,x,x,x,,,
 fnmadd.s,FR4,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,x,x,x,x,frm,x,,x,x,x,,,
+fsub.s,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,x,x,,x,frm,,,x,x,x,,,
 fmul.s,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,x,x,,x,frm,,,x,x,x,,,
 fdiv.s,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,x,x,,x,frm,,,x,x,x,,,
 fsgnj.s,FR,x,,,,,,,,,,,,,,,,x,x,x,x,,,,,,,,,,,,,,,,,,,,,,,x,x,x,x,,,,,,x,x,x,,,


### PR DESCRIPTION
Reverts openhwgroup/cvw-arch-verif#129

This PR set the rounding mode on all instructions.  Some instructions such as fmax don't use corners, so the assembly language doesn't compile.