### PR TITLE
Updated cp_fs*_corners to only check bottom 32 bits of floating-point register value

### DIFF
--- a/templates/cp_fs1_corners.txt
+++ b/templates/cp_fs1_corners.txt
@@ -1,4 +1,4 @@
-    cp_fs1_corners : coverpoint unsigned'(ins.current.fs1_val)  iff (ins.trap == 0 )  {
+    cp_fs1_corners : coverpoint unsigned'(ins.current.fs1_val[31:0])  iff (ins.trap == 0 )  {
         option.comment = "FS1 corners";
         bins pos0             = {32'h00000000};
         bins neg0             = {32'h80000000};

--- a/templates/cp_fs2_corners.txt
+++ b/templates/cp_fs2_corners.txt
@@ -1,4 +1,4 @@
-    cp_fs2_corners : coverpoint unsigned'(ins.current.fs2_val)  iff (ins.trap == 0 )  {
+    cp_fs2_corners : coverpoint unsigned'(ins.current.fs2_val[31:0])  iff (ins.trap == 0 )  {
         option.comment = "FS2 corners";
         bins pos0             = {32'h00000000};
         bins neg0             = {32'h80000000};

--- a/templates/cp_fs3_corners.txt
+++ b/templates/cp_fs3_corners.txt
@@ -1,4 +1,4 @@
-    cp_fs3_corners : coverpoint unsigned'(ins.current.fs3_val)  iff (ins.trap == 0 )  {
+    cp_fs3_corners : coverpoint unsigned'(ins.current.fs3_val[31:0])  iff (ins.trap == 0 )  {
         option.comment = "FS3 corners";
         bins pos0             = {32'h00000000};
         bins neg0             = {32'h80000000};


### PR DESCRIPTION
This makes it possible to check that the proper value is held in the 64-bit floating-point registers in the rv64gc hardware configuration while maintaining the ability to use the same tests on a rv64f hardware configuration machine with 32-bit floating-point registers. 

This change gets 64-bit fsw to 100% and increases coverage for rv64f instructions with any of the cp_fs*_corners coverpoints. 

cp_fs*_corners_D coming soon for 64-bit floating-point register corner values. 