### PR TITLE
Created double precision fp corner values

### DIFF
--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -588,71 +588,23 @@ def make_cr_fs1_fs2_corners(test, xlen):
       desc = "cr_fs1_fs2_corners (Test source fs1 = " + hex(v1) + " fs2 = " + hex(v2) + ")"
       writeCovVector(desc, rs1, rs2, rd, v1, v2, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
-def make_fs1_corners(test, xlen, flen = "F"):
-  if flen == "F":
-    for v in fcorners:
-      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
-      desc = "cp_fs1_corners (Test source fs1 value = " + hex(v) + ")"
-      writeCovVector(desc, rs1, rs2, rd, v, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
-  elif flen == "D":
-    for v in fcornersD:
-      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
-      desc = "cp_fs1_corners (Test source fs1 value = " + hex(v) + ")"
-      writeCovVector(desc, rs1, rs2, rd, v, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
-  elif flen == "H":
-    for v in fcornersH:
-      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
-      desc = "cp_fs1_corners (Test source fs1 value = " + hex(v) + ")"
-      writeCovVector(desc, rs1, rs2, rd, v, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
-  elif flen == "Q":
-    for v in fcornersQ:
-      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
-      desc = "cp_fs1_corners (Test source fs1 value = " + hex(v) + ")"
-      writeCovVector(desc, rs1, rs2, rd, v, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
+def make_fs1_corners(test, xlen, fcorners):
+  for v in fcorners:
+    [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
+    desc = "cp_fs1_corners (Test source fs1 value = " + hex(v) + ")"
+    writeCovVector(desc, rs1, rs2, rd, v, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
-def make_fs2_corners(test, xlen, flen = "F"):
-  if flen == "F":
-    for v in fcorners:
-      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
-      desc = "cp_fs2_corners (Test source fs2 value = " + hex(v) + ")"
-      writeCovVector(desc, rs1, rs2, rd, rs1val, v, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
-  if flen == "D":
-    for v in fcornersD:
-      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
-      desc = "cp_fs2_corners (Test source fs2 value = " + hex(v) + ")"
-      writeCovVector(desc, rs1, rs2, rd, rs1val, v, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
-  if flen == "H":
-    for v in fcornersH:
-      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
-      desc = "cp_fs2_corners (Test source fs2 value = " + hex(v) + ")"
-      writeCovVector(desc, rs1, rs2, rd, rs1val, v, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
-  if flen == "Q":
-    for v in fcornersQ:
-      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
-      desc = "cp_fs2_corners (Test source fs2 value = " + hex(v) + ")"
-      writeCovVector(desc, rs1, rs2, rd, rs1val, v, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
+def make_fs2_corners(test, xlen, fcorners):
+  for v in fcorners:
+    [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
+    desc = "cp_fs2_corners (Test source fs2 value = " + hex(v) + ")"
+    writeCovVector(desc, rs1, rs2, rd, rs1val, v, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
-def make_fs3_corners(test, xlen, flen = "F"):
-  if flen == "F":
-    for v in fcorners:
-      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
-      desc = "cp_fs3_corners (Test source fs3 value = " + hex(v) + ")"
-      writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=v)
-  if flen == "D":
-    for v in fcornersD:
-      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
-      desc = "cp_fs3_corners (Test source fs3 value = " + hex(v) + ")"
-      writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=v)
-  if flen == "H":
-    for v in fcornersH:
-      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
-      desc = "cp_fs3_corners (Test source fs3 value = " + hex(v) + ")"
-      writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=v)
-  if flen == "Q":
-    for v in fcornersQ:
-      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
-      desc = "cp_fs3_corners (Test source fs3 value = " + hex(v) + ")"
-      writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=v)
+def make_fs3_corners(test, xlen, fcorners):
+  for v in fcorners:
+    [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
+    desc = "cp_fs3_corners (Test source fs3 value = " + hex(v) + ")"
+    writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=v)
 
 def write_tests(coverpoints, test, xlen):
   for coverpoint in coverpoints:
@@ -671,29 +623,29 @@ def write_tests(coverpoints, test, xlen):
     elif (coverpoint == "cp_fs2"):
       make_fs2(test, xlen)
     elif (coverpoint == "cp_fs1_corners"):
-      make_fs1_corners(test, xlen)
+      make_fs1_corners(test, xlen, fcorners)
     elif (coverpoint == "cp_fs2_corners"):
-      make_fs2_corners(test, xlen)
+      make_fs2_corners(test, xlen, fcorners)
     elif (coverpoint == "cp_fs3_corners"):
-      make_fs3_corners(test, xlen)
+      make_fs3_corners(test, xlen, fcorners)
     elif (coverpoint == "cp_fs1_corners_D"):
-      make_fs1_corners(test, xlen, flen = "D")
+      make_fs1_corners(test, xlen, fcornersD)
     elif (coverpoint == "cp_fs2_corners_D"):
-      make_fs2_corners(test, xlen, flen = "D")
+      make_fs2_corners(test, xlen, fcornersD)
     elif (coverpoint == "cp_fs3_corners_D"):
-      make_fs3_corners(test, xlen, flen = "D")
+      make_fs3_corners(test, xlen, fcornersD)
     elif (coverpoint == "cp_fs1_corners_H"):
-      make_fs1_corners(test, xlen, flen = "H")
+      make_fs1_corners(test, xlen, fcornersH)
     elif (coverpoint == "cp_fs2_corners_H"):
-      make_fs2_corners(test, xlen, flen = "H")
+      make_fs2_corners(test, xlen, fcornersH)
     elif (coverpoint == "cp_fs3_corners_H"):
-      make_fs3_corners(test, xlen, flen = "H")
-    elif (coverpoint == "cp_fs1_corners_Q"):
-      make_fs1_corners(test, xlen, flen = "Q")
-    elif (coverpoint == "cp_fs2_corners_Q"):
-      make_fs2_corners(test, xlen, flen = "Q")
-    elif (coverpoint == "cp_fs3_corners_Q"):
-      make_fs3_corners(test, xlen, flen = "Q")
+      make_fs3_corners(test, xlen, fcornersH)
+    # elif (coverpoint == "cp_fs1_corners_Q"):
+    #   make_fs1_corners(test, xlen, fcornersQ)
+    # elif (coverpoint == "cp_fs2_corners_Q"):
+    #   make_fs2_corners(test, xlen, fcornersQ)
+    # elif (coverpoint == "cp_fs3_corners_Q"):
+    #   make_fs3_corners(test, xlen, fcornersQ)
     elif (coverpoint == "cp_rs1"):
       make_rs1(test, xlen)
     elif (coverpoint == "cp_rs2" or coverpoint == "cp_rs2_nx0"):
@@ -1004,7 +956,7 @@ if __name__ == '__main__':
                   0xA6E895993737426C]
       
       fcornersH = [] # TODO: Fill out half precision F corners
-      fcornersQ = [] # TODO: Fill out quad precision F corners
+      # fcornersQ = [] # TODO: Fill out quad precision F corners
 
       WALLY = os.environ.get('WALLY')
       pathname = WALLY+"/addins/cvw-arch-verif/tests/rv" + str(xlen) + "/"+extension+"/"

--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -588,17 +588,71 @@ def make_cr_fs1_fs2_corners(test, xlen):
       desc = "cr_fs1_fs2_corners (Test source fs1 = " + hex(v1) + " fs2 = " + hex(v2) + ")"
       writeCovVector(desc, rs1, rs2, rd, v1, v2, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
-def make_fs1_corners(test, xlen):
-  for v in fcorners:
-    [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
-    desc = "cp_fs1_corners (Test source fs1 value = " + hex(v) + ")"
-    writeCovVector(desc, rs1, rs2, rd, v, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
+def make_fs1_corners(test, xlen, flen = "F"):
+  if flen == "F":
+    for v in fcorners:
+      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
+      desc = "cp_fs1_corners (Test source fs1 value = " + hex(v) + ")"
+      writeCovVector(desc, rs1, rs2, rd, v, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
+  elif flen == "D":
+    for v in fcornersD:
+      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
+      desc = "cp_fs1_corners (Test source fs1 value = " + hex(v) + ")"
+      writeCovVector(desc, rs1, rs2, rd, v, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
+  elif flen == "H":
+    for v in fcornersH:
+      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
+      desc = "cp_fs1_corners (Test source fs1 value = " + hex(v) + ")"
+      writeCovVector(desc, rs1, rs2, rd, v, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
+  elif flen == "Q":
+    for v in fcornersQ:
+      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
+      desc = "cp_fs1_corners (Test source fs1 value = " + hex(v) + ")"
+      writeCovVector(desc, rs1, rs2, rd, v, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
-def make_fs2_corners(test, xlen):
-  for v in fcorners:
-    [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
-    desc = "cp_fs2_corners (Test source fs2 value = " + hex(v) + ")"
-    writeCovVector(desc, rs1, rs2, rd, rs1val, v, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
+def make_fs2_corners(test, xlen, flen = "F"):
+  if flen == "F":
+    for v in fcorners:
+      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
+      desc = "cp_fs2_corners (Test source fs2 value = " + hex(v) + ")"
+      writeCovVector(desc, rs1, rs2, rd, rs1val, v, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
+  if flen == "D":
+    for v in fcornersD:
+      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
+      desc = "cp_fs2_corners (Test source fs2 value = " + hex(v) + ")"
+      writeCovVector(desc, rs1, rs2, rd, rs1val, v, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
+  if flen == "H":
+    for v in fcornersH:
+      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
+      desc = "cp_fs2_corners (Test source fs2 value = " + hex(v) + ")"
+      writeCovVector(desc, rs1, rs2, rd, rs1val, v, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
+  if flen == "Q":
+    for v in fcornersQ:
+      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
+      desc = "cp_fs2_corners (Test source fs2 value = " + hex(v) + ")"
+      writeCovVector(desc, rs1, rs2, rd, rs1val, v, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
+
+def make_fs3_corners(test, xlen, flen = "F"):
+  if flen == "F":
+    for v in fcorners:
+      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
+      desc = "cp_fs3_corners (Test source fs3 value = " + hex(v) + ")"
+      writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=v)
+  if flen == "D":
+    for v in fcornersD:
+      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
+      desc = "cp_fs3_corners (Test source fs3 value = " + hex(v) + ")"
+      writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=v)
+  if flen == "H":
+    for v in fcornersH:
+      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
+      desc = "cp_fs3_corners (Test source fs3 value = " + hex(v) + ")"
+      writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=v)
+  if flen == "Q":
+    for v in fcornersQ:
+      [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
+      desc = "cp_fs3_corners (Test source fs3 value = " + hex(v) + ")"
+      writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=v)
 
 def write_tests(coverpoints, test, xlen):
   for coverpoint in coverpoints:
@@ -620,6 +674,26 @@ def write_tests(coverpoints, test, xlen):
       make_fs1_corners(test, xlen)
     elif (coverpoint == "cp_fs2_corners"):
       make_fs2_corners(test, xlen)
+    elif (coverpoint == "cp_fs3_corners"):
+      make_fs3_corners(test, xlen)
+    elif (coverpoint == "cp_fs1_corners_D"):
+      make_fs1_corners(test, xlen, flen = "D")
+    elif (coverpoint == "cp_fs2_corners_D"):
+      make_fs2_corners(test, xlen, flen = "D")
+    elif (coverpoint == "cp_fs3_corners_D"):
+      make_fs3_corners(test, xlen, flen = "D")
+    elif (coverpoint == "cp_fs1_corners_H"):
+      make_fs1_corners(test, xlen, flen = "H")
+    elif (coverpoint == "cp_fs2_corners_H"):
+      make_fs2_corners(test, xlen, flen = "H")
+    elif (coverpoint == "cp_fs3_corners_H"):
+      make_fs3_corners(test, xlen, flen = "H")
+    elif (coverpoint == "cp_fs1_corners_Q"):
+      make_fs1_corners(test, xlen, flen = "Q")
+    elif (coverpoint == "cp_fs2_corners_Q"):
+      make_fs2_corners(test, xlen, flen = "Q")
+    elif (coverpoint == "cp_fs3_corners_Q"):
+      make_fs3_corners(test, xlen, flen = "Q")
     elif (coverpoint == "cp_rs1"):
       make_rs1(test, xlen)
     elif (coverpoint == "cp_rs2" or coverpoint == "cp_rs2_nx0"):
@@ -734,10 +808,10 @@ def write_tests(coverpoints, test, xlen):
       make_fd_fs1(test, xlen)
     elif (coverpoint == "cmp_fd_fs2"):
       make_fd_fs2(test, xlen)
-    elif (coverpoint == "cp_fs1_corners"):
-      make_fs1_corners(test, xlen)
-    elif (coverpoint == "cp_fs2_corners"):
-      make_fs2_corners(test, xlen)
+    # elif (coverpoint == "cp_fs1_corners"):
+    #   make_fs1_corners(test, xlen)
+    # elif (coverpoint == "cp_fs2_corners"):
+    #   make_fs2_corners(test, xlen)
     elif (coverpoint == "cr_fs1_fs2_corners"):
       make_cr_fs1_fs2_corners(test, xlen)
     else:
@@ -897,13 +971,40 @@ if __name__ == '__main__':
                             0b10101010101010101010101010101010,0b10110111011110010001000011101110]
       c_srai_32_corners  = [0,2,4,0b11111111111111111111111111111110, 0b00110111011110010001000011101110]                   
       
-      # TODO: DELETEME if this breaks something
+      
       fcorners = [0x00000000, 0x80000000, 0x3f800000, 0xbf800000, 0x3fc00000, 0xbfc00000, 0x40000000, 0xc0000000, 0x00800000, 
                   0x80800000, 0x7f7fffff, 0xff7fffff, 0x007fffff, 0x807fffff, 0x00400000, 0x80400000, 0x00000001, 0x80000001, 
                   0x7f800000, 0xff800000, 0x7fc00000, 0x7fffffff, 0x7f800000, 0x7fbfffff, 0x7ef8654f, 0x813d9ab0]
-
       
-
+      fcornersD = [0x0000000000000000,
+                  0x8000000000000000,
+                  0x3FF0000000000000,
+                  0xBFF0000000000000,
+                  0x3FF8000000000000,
+                  0xBFF8000000000000,
+                  0x4000000000000000,
+                  0xc000000000000000,
+                  0x0010000000000000,
+                  0x8010000000000000,
+                  0x7FEFFFFFFFFFFFFF,
+                  0xFFEFFFFFFFFFFFFF,
+                  0x000FFFFFFFFFFFFF,
+                  0x800FFFFFFFFFFFFF,
+                  0x0008000000000000,
+                  0x8008000000000000,
+                  0x0000000000000001,
+                  0x8000000000000001,
+                  0x7FF0000000000000,
+                  0xFFF0000000000000,
+                  0x7FF8000000000000, 
+                  0x7FFFFFFFFFFFFFFF,
+                  0x77FF000000000000,
+                  0x7FF7FFFFFFFFFFFF,
+                  0x5A392534A57711AD, 
+                  0xA6E895993737426C]
+      
+      fcornersH = [] # TODO: Fill out half precision F corners
+      fcornersQ = [] # TODO: Fill out quad precision F corners
 
       WALLY = os.environ.get('WALLY')
       pathname = WALLY+"/addins/cvw-arch-verif/tests/rv" + str(xlen) + "/"+extension+"/"

--- a/templates/cp_fs1_corners_D.txt
+++ b/templates/cp_fs1_corners_D.txt
@@ -1,0 +1,27 @@
+    cp_fs1_corners_D : coverpoint unsigned'(ins.current.fs1_val[63:0])  iff (ins.trap == 0 )  {
+        option.comment = "FS1 corners (Double Precision)";
+        bins pos0             = {64'h0000000000000000};
+        bins neg0             = {64'h8000000000000000};
+        bins pos1             = {64'h3FF0000000000000};
+        bins neg1             = {64'hBFF0000000000000};
+        bins pos1p5           = {64'h3FF8000000000000};
+        bins neg1p5           = {64'hBFF8000000000000};
+        bins pos2             = {64'h4000000000000000};
+        bins neg2             = {64'hc000000000000000};
+        bins posminnorm       = {64'h0010000000000000};
+        bins mnegminnorm      = {64'h8010000000000000};
+        bins posmaxnorm       = {64'h7FEFFFFFFFFFFFFF};
+        bins negmaxnorm       = {64'hFFEFFFFFFFFFFFFF};
+        bins posmax_subnorm   = {64'h000FFFFFFFFFFFFF};
+        bins negmax_subnorm   = {64'h800FFFFFFFFFFFFF};
+        bins posmid_subnorm   = {64'h0008000000000000};
+        bins negmid_subnorm   = {64'h8008000000000000};
+        bins posmin_subnorm   = {64'h0000000000000001};
+        bins negmin_subnorm   = {64'h8000000000000001};
+        bins posinfinity      = {64'h7FF0000000000000};
+        bins neginfinity      = {64'hFFF0000000000000};
+        bins posQNaN          = {[64'h7FF8000000000000:64'h7FFFFFFFFFFFFFFF]};
+        bins posSNaN          = {[64'h77FF000000000000:64'h7FF7FFFFFFFFFFFF]};
+        bins posrandom        = {64'h5A392534A57711AD};
+        bins negrandom        = {64'hA6E895993737426C};
+    }

--- a/templates/cp_fs2_corners_D.txt
+++ b/templates/cp_fs2_corners_D.txt
@@ -1,0 +1,27 @@
+    cp_fs2_corners_D : coverpoint unsigned'(ins.current.fs2_val[63:0])  iff (ins.trap == 0 )  {
+        option.comment = "FS2 corners (Double Precision)";
+        bins pos0             = {64'h0000000000000000};
+        bins neg0             = {64'h8000000000000000};
+        bins pos1             = {64'h3FF0000000000000};
+        bins neg1             = {64'hBFF0000000000000};
+        bins pos1p5           = {64'h3FF8000000000000};
+        bins neg1p5           = {64'hBFF8000000000000};
+        bins pos2             = {64'h4000000000000000};
+        bins neg2             = {64'hc000000000000000};
+        bins posminnorm       = {64'h0010000000000000};
+        bins mnegminnorm      = {64'h8010000000000000};
+        bins posmaxnorm       = {64'h7FEFFFFFFFFFFFFF};
+        bins negmaxnorm       = {64'hFFEFFFFFFFFFFFFF};
+        bins posmax_subnorm   = {64'h000FFFFFFFFFFFFF};
+        bins negmax_subnorm   = {64'h800FFFFFFFFFFFFF};
+        bins posmid_subnorm   = {64'h0008000000000000};
+        bins negmid_subnorm   = {64'h8008000000000000};
+        bins posmin_subnorm   = {64'h0000000000000001};
+        bins negmin_subnorm   = {64'h8000000000000001};
+        bins posinfinity      = {64'h7FF0000000000000};
+        bins neginfinity      = {64'hFFF0000000000000};
+        bins posQNaN          = {[64'h7FF8000000000000:64'h7FFFFFFFFFFFFFFF]};
+        bins posSNaN          = {[64'h77FF000000000000:64'h7FF7FFFFFFFFFFFF]};
+        bins posrandom        = {64'h5A392534A57711AD};
+        bins negrandom        = {64'hA6E895993737426C};
+    }

--- a/templates/cp_fs3_corners_D.txt
+++ b/templates/cp_fs3_corners_D.txt
@@ -1,0 +1,27 @@
+    cp_fs3_corners_D : coverpoint unsigned'(ins.current.fs3_val[63:0])  iff (ins.trap == 0 )  {
+        option.comment = "FS3 corners (Double Precision)";
+        bins pos0             = {64'h0000000000000000};
+        bins neg0             = {64'h8000000000000000};
+        bins pos1             = {64'h3FF0000000000000};
+        bins neg1             = {64'hBFF0000000000000};
+        bins pos1p5           = {64'h3FF8000000000000};
+        bins neg1p5           = {64'hBFF8000000000000};
+        bins pos2             = {64'h4000000000000000};
+        bins neg2             = {64'hc000000000000000};
+        bins posminnorm       = {64'h0010000000000000};
+        bins mnegminnorm      = {64'h8010000000000000};
+        bins posmaxnorm       = {64'h7FEFFFFFFFFFFFFF};
+        bins negmaxnorm       = {64'hFFEFFFFFFFFFFFFF};
+        bins posmax_subnorm   = {64'h000FFFFFFFFFFFFF};
+        bins negmax_subnorm   = {64'h800FFFFFFFFFFFFF};
+        bins posmid_subnorm   = {64'h0008000000000000};
+        bins negmid_subnorm   = {64'h8008000000000000};
+        bins posmin_subnorm   = {64'h0000000000000001};
+        bins negmin_subnorm   = {64'h8000000000000001};
+        bins posinfinity      = {64'h7FF0000000000000};
+        bins neginfinity      = {64'hFFF0000000000000};
+        bins posQNaN          = {[64'h7FF8000000000000:64'h7FFFFFFFFFFFFFFF]};
+        bins posSNaN          = {[64'h77FF000000000000:64'h7FF7FFFFFFFFFFFF]};
+        bins posrandom        = {64'h5A392534A57711AD};
+        bins negrandom        = {64'hA6E895993737426C};
+    }


### PR DESCRIPTION
Also made modifications to testgen.py to accommodate different flen when making tests to hit cp_fs*_corners. 

fcorners (implicitly single), fcornersD are defined with fcornersQ and fcornersH coming soon. 
make_fs*_corners takes a parameter for flen, which is default to "F"
In write_tests, when coverpoint == cp_fs*_corners_<precision>, make_fs*_corners is called with the flen parameter set to a string with the single letter precision (D, Q, H). 