### PR TITLE
c.sb & c.sh 100% Coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,14 +54,14 @@ CMPR_FLAG = $(if $(findstring /Zc, $(dir $<)),c,)
 
 # Change many things if bit width isn't 64
 $(SRCDIR64)/%.elf: $(SRCDIR64)/%.$(SEXT) 
-	riscv64-unknown-elf-gcc -g -o $@ -march=rv64gq$(CMPR_FLAG)_zfa_zba_zbb_zbc_zbs_zfh_zicboz_zicbop_zicbom_zicond -mabi=lp64 -mcmodel=medany \
+	riscv64-unknown-elf-gcc -g -o $@ -march=rv64gq$(CMPR_FLAG)_zcb_zfa_zba_zbb_zbc_zbs_zfh_zicboz_zicbop_zicbom_zicond -mabi=lp64 -mcmodel=medany \
 	    -nostartfiles -T${WALLY}/examples/link/link.ld $<
 	riscv64-unknown-elf-objdump -S -D $@ > $@.objdump
 	riscv64-unknown-elf-elf2hex --bit-width 64 --input $@ --output $@.memfile
 	extractFunctionRadix.sh $@.objdump
 
 $(SRCDIR32)/%.elf: $(SRCDIR32)/%.$(SEXT) 
-	riscv64-unknown-elf-gcc -g -o $@ -march=rv32gq$(CMPR_FLAG)_zfa_zba_zbb_zbc_zbs_zfh_zicboz_zicbop_zicbom_zicond -mabi=ilp32 -mcmodel=medany \
+	riscv64-unknown-elf-gcc -g -o $@ -march=rv32gq$(CMPR_FLAG)_zcb_zfa_zba_zbb_zbc_zbs_zfh_zicboz_zicbop_zicbom_zicond -mabi=ilp32 -mcmodel=medany \
 	    -nostartfiles -T${WALLY}/examples/link/link.ld $<
 	riscv64-unknown-elf-objdump -S -D $@ > $@.objdump
 	riscv64-unknown-elf-elf2hex --bit-width 32 --input $@ --output $@.memfile

--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -76,7 +76,6 @@ def unsignedImm1(imm):
   imm = imm % pow(2, 1)
   return str(imm)
 
-
 def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=None, rs3val=None, frm=False):
   lines = "\n# Testcase " + str(desc) + "\n"
   if (rs1val < 0):
@@ -216,7 +215,6 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
     lines = lines + "la x" + str(rs1) + ", scratch" + " # base address \n"
     lines = lines + "addi x" + str(rs1) + ", x" + str(rs1) + ", -" + unsignedImm2(immval) + " # sub immediate from rs1 to counter offset\n"
     lines = lines + test + " x" + str(rs2) + ", " + unsignedImm2(immval) + "(x" + str(rs1) + ") # perform operation \n"
-
   elif (test in cshtype):
     rs1 = legalizecompr(rs1)
     rs2 = legalizecompr(rs2)
@@ -226,7 +224,6 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
     lines = lines + "la x" + str(rs1) + ", scratch" + " # base address \n"
     lines = lines + "addi x" + str(rs1) + ", x" + str(rs1) + ", -" + str(int(unsignedImm1(immval))*2) + " # sub immediate from rs1 to counter offset\n"
     lines = lines + test + " x" + str(rs2) + ", " + str(int(unsignedImm1(immval))*2) + "(x" + str(rs1) + ") # perform operation \n"
-  
   elif (test in stype):#["sb", "sh", "sw", "sd"]
     if (rs1 != 0):
       if (rs2 == rs1): # make sure registers are different so they don't conflict

--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -68,6 +68,15 @@ def unsignedImm8(imm):
     imm = 16
   return str(imm)
 
+def unsignedImm2(imm):
+  imm = imm % pow(2, 2)
+  return str(imm)
+
+def unsignedImm1(imm):
+  imm = imm % pow(2, 1)
+  return str(imm)
+
+
 def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=None, rs3val=None, frm=False):
   lines = "\n# Testcase " + str(desc) + "\n"
   if (rs1val < 0):
@@ -198,6 +207,26 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
     lines = lines + "la x" + str(rs1) + ", scratch" + " # base address \n"
     lines = lines + "addi x" + str(rs1) + ", x" + str(rs1) + ", -" + str(int(unsignedImm6(immval))*mul) + " # sub immediate from rs1 to counter offset\n"
     lines = lines + test + " x" + str(rs2) + ", " + str(int(unsignedImm6(immval))*mul) + "(x" + str(rs1) + ") # perform operation \n"
+  elif (test in csbtype):
+    rs1 = legalizecompr(rs1)
+    rs2 = legalizecompr(rs2)
+    while (rs1 == rs2):
+      rs2 = randint(8,15)
+    lines = lines + "li x" + str(rs2) + ", " + formatstr.format(rs2val)  + " # initialize rs2\n"
+    lines = lines + "la x" + str(rs1) + ", scratch" + " # base address \n"
+    lines = lines + "addi x" + str(rs1) + ", x" + str(rs1) + ", -" + unsignedImm2(immval) + " # sub immediate from rs1 to counter offset\n"
+    lines = lines + test + " x" + str(rs2) + ", " + unsignedImm2(immval) + "(x" + str(rs1) + ") # perform operation \n"
+
+  elif (test in cshtype):
+    rs1 = legalizecompr(rs1)
+    rs2 = legalizecompr(rs2)
+    while (rs1 == rs2):
+      rs2 = randint(8,15)
+    lines = lines + "li x" + str(rs2) + ", " + formatstr.format(rs2val)  + " # initialize rs2\n"
+    lines = lines + "la x" + str(rs1) + ", scratch" + " # base address \n"
+    lines = lines + "addi x" + str(rs1) + ", x" + str(rs1) + ", -" + str(int(unsignedImm1(immval))*2) + " # sub immediate from rs1 to counter offset\n"
+    lines = lines + test + " x" + str(rs2) + ", " + str(int(unsignedImm1(immval))*2) + "(x" + str(rs1) + ") # perform operation \n"
+  
   elif (test in stype):#["sb", "sh", "sw", "sd"]
     if (rs1 != 0):
       if (rs2 == rs1): # make sure registers are different so they don't conflict
@@ -906,6 +935,8 @@ if __name__ == '__main__':
   cbptype = ["c.andi"]
   cbtype = ["c.beqz", "c.bnez"]
   shiftwtype = ["sraiw", "srliw"]
+  csbtype = ["c.sb"]
+  cshtype = ["c.sh"]
 
   floattypes = frtype + fstype + fltype + fcomptype + F2Xtype + fr4type + fitype + fixtype
   # instructions with all float args
@@ -926,7 +957,7 @@ if __name__ == '__main__':
 
   # generate files for each test
   for xlen in xlens:
-    for extension in ["I", "M", "F", "Zicond","Zca", "Zfh"]:
+    for extension in ["I", "M", "F", "Zicond","Zca","Zfh","Zcb"]:
       coverdefdir = WALLY+"/addins/cvw-arch-verif/fcov/rv"+str(xlen)
       coverfiles = ["RV"+str(xlen)+extension] 
       coverpoints = getcovergroups(coverdefdir, coverfiles)

--- a/templates/sample_RV32Zcb.txt
+++ b/templates/sample_RV32Zcb.txt
@@ -1,0 +1,60 @@
+function void rv32zcb_sample(int hart, int issue);
+    ins_rv32zcb_t ins;
+
+    if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
+        $display("Examining compressed instruction rv32zcb_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
+        case (traceDataQ[hart][issue][0].inst_name)
+            "lbu"    : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);                 
+                ins.add_imm(1);                
+                ins.add_rs1(2);                
+                ins.current.inst_category = INST_CAT_LOAD;
+                ins.add_mem_address();         
+                c_lbu_cg.sample(ins); 
+            end
+            "lh"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);                 
+                ins.add_imm(1);                
+                ins.add_rs1(2);                
+                ins.current.inst_category = INST_CAT_LOAD;
+                ins.add_mem_address();         
+                c_lh_cg.sample(ins); 
+            end
+            "lhu"    : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);                 
+                ins.add_imm(1);                
+                ins.add_rs1(2);                
+                ins.current.inst_category = INST_CAT_LOAD;
+                ins.add_mem_address();         
+                c_lhu_cg.sample(ins); 
+            end
+            "sb"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rs2(0);                
+                ins.add_imm(1);                
+                ins.add_rs1(2);                
+                ins.current.inst_category = INST_CAT_STORE;
+                ins.add_mem_address();         
+                c_sb_cg.sample(ins); 
+            end
+            "sh"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rs2(0);                
+                ins.add_imm(1);                
+                ins.add_rs1(2);                
+                ins.current.inst_category = INST_CAT_STORE;
+                ins.add_mem_address();         
+                c_sh_cg.sample(ins); 
+            end
+            "not"    : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);                 
+                ins.add_rs1(1);                
+                c_not_cg.sample(ins); 
+            end
+        endcase
+    end
+endfunction

--- a/testplans/RV32Zcb.csv
+++ b/testplans/RV32Zcb.csv
@@ -1,8 +1,8 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_gpr_hazard,cp_rd_corners,cmp_rd_rs1,cmp_rd_rs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rd_corners,cp_rs2_corners,cp_rd_toggle,cp_rs2_toggle,cp_rs1p,cp_rs1_corners,cp_rs1_toggle,cp_fdp,cp_fs2p,cr_rs1_imm_corners
-c.lbu,L,x,,,,,,,,,x,,,,,,,,,,,,,,,,,,,,x,,x,,x,,x,x,x,x,x
-c.lh,L,x,,,,,,,,,x,,,,,,,,,,,,,,,,,,,,x,,x,,x,,x,x,x,x,x
-c.lhu,L,x,,,,,,,,,x,,,,,,,,,,,,,,,,,,,,x,,x,,x,,x,x,x,x,x
-c.sb,S,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,,x,x,x,x,x,x
-c.sh,S,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,,x,x,x,x,x,x
+c.lbu,L,x,,,,,,,,,x,,,,,,,,,,,,,,,,,,,,x,,x,,x,,x,x,x,,
+c.lh,L,x,,,,,,,,,x,,,,,,,,,,,,,,,,,,,,x,,x,,x,,x,x,x,,
+c.lhu,L,x,,,,,,,,,x,,,,,,,,,,,,,,,,,,,,x,,x,,x,,x,x,x,,
+c.sb,CSB,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,,x,x,,,,
+c.sh,S,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,,x,x,,,,
 c.not,CR1,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,,x,,,,,,
 c.zext.b,CR1,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,,x,,,,,,


### PR DESCRIPTION
Exclude checks from coverpoints like cp_rs1_corners, cp_rs1_toggle as rs1 is just a base address "scratch". Also exclude cp_fdp and cp_fs2p. Also made a change in makefile which is required. Please let me know, if anything can be improved.  