### PR TITLE
Compressed instruction bug fixes for sw/swsp

### DIFF
--- a/fcov/coverage/RISCV_instruction_base.svh
+++ b/fcov/coverage/RISCV_instruction_base.svh
@@ -366,6 +366,12 @@ class RISCV_instruction
         current.rs1_val = 0;
     endfunction
 
+    virtual function void add_rs1_2();
+        current.has_rs1 = 1;
+        current.rs1 = "x2";
+        current.rs1_val = prev.x_wdata[get_gpr_num("x2")];
+    endfunction
+
     virtual function void add_rs2(int offset);
         current.has_rs2 = 1;
         current.rs2 = ops[offset].key;

--- a/templates/sample_RV32Zca.txt
+++ b/templates/sample_RV32Zca.txt
@@ -37,13 +37,23 @@ function void rv32zca_sample(int hart, int issue);
                 c_lw_cg.sample(ins); 
             end
             "sw"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rs2(0);
-                ins.add_imm(1);
-                ins.add_rs1(2);
-                ins.current.inst_category = INST_CAT_STORE;
-                ins.add_mem_address();
-                c_sw_cg.sample(ins); 
+                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00 & traceDataQ[hart][issue][0].insn[15:13] == 3'b110) begin // normal sw
+                    ins = new(hart, issue, traceDataQ); 
+                    ins.add_rs2(0);
+                    ins.add_imm(1);
+                    ins.add_rs1(2);
+                    ins.current.inst_category = INST_CAT_STORE;
+                    ins.add_mem_address();
+                    c_sw_cg.sample(ins); 
+                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b10 & traceDataQ[hart][issue][0].insn[15:13] == 3'b110) begin // swsp
+                    ins = new(hart, issue, traceDataQ); 
+                    ins.add_rs2(0);
+                    ins.add_imm(1);
+                    ins.add_rs1_2();
+                    ins.current.inst_category = INST_CAT_STORE;
+                    ins.add_mem_address();
+                    c_swsp_cg.sample(ins); 
+                end 
             end
             "li"     : begin 
                 ins = new(hart, issue, traceDataQ); 
@@ -154,15 +164,6 @@ function void rv32zca_sample(int hart, int issue);
                 ins.add_rd(0);
                 ins.add_rs2(2);
                 c_add_cg.sample(ins); 
-            end
-            "swsp"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rs2(0);
-                ins.add_imm(1);
-                ins.add_rs1(2);
-                ins.current.inst_category = INST_CAT_STORE;
-                ins.add_mem_address();
-                c_swsp_cg.sample(ins); 
             end
             "jal"     : begin 
                 ins = new(hart, issue, traceDataQ); 

--- a/templates/sample_RV64Zca.txt
+++ b/templates/sample_RV64Zca.txt
@@ -46,13 +46,23 @@ function void rv64zca_sample(int hart, int issue);
                 c_ld_cg.sample(ins); 
             end
             "sw"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rs2(0);
-                ins.add_imm(1);
-                ins.add_rs1(2);
-                ins.current.inst_category = INST_CAT_STORE;
-                ins.add_mem_address();
-                c_sw_cg.sample(ins); 
+                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00 & traceDataQ[hart][issue][0].insn[15:13] == 3'b110) begin // normal sw
+                    ins = new(hart, issue, traceDataQ); 
+                    ins.add_rs2(0);
+                    ins.add_imm(1);
+                    ins.add_rs1(2);
+                    ins.current.inst_category = INST_CAT_STORE;
+                    ins.add_mem_address();
+                    c_sw_cg.sample(ins); 
+                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b10 & traceDataQ[hart][issue][0].insn[15:13] == 3'b110) begin // swsp
+                    ins = new(hart, issue, traceDataQ); 
+                    ins.add_rs2(0);
+                    ins.add_imm(1);
+                    ins.add_rs1_2();
+                    ins.current.inst_category = INST_CAT_STORE;
+                    ins.add_mem_address();
+                    c_swsp_cg.sample(ins); 
+                end 
             end
             "sd"     : begin 
                 ins = new(hart, issue, traceDataQ); 
@@ -179,15 +189,6 @@ function void rv64zca_sample(int hart, int issue);
                 ins.add_rd(0);
                 ins.add_rs2(2);
                 c_add_cg.sample(ins); 
-            end
-            "swsp"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rs2(0);
-                ins.add_imm(1);
-                ins.add_rs1(2);
-                ins.current.inst_category = INST_CAT_STORE;
-                ins.add_mem_address();
-                c_swsp_cg.sample(ins); 
             end
             "sdsp"     : begin 
                 ins = new(hart, issue, traceDataQ); 


### PR DESCRIPTION
Some compressed instructions intended to be interpreted as swsp were instead being read as sw rs2 imm(x2), breaking regression. I made changes to RISCV_instruction_base.svh to properly interpret these instructions similar to the different versions of addi. 