### PR TITLE
c.lh, c.lhu & c.lbu 100% Coverage for RV32Zcb

### DIFF
--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -191,8 +191,25 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
     lines = lines + "li x" + str(rs2) + ", " + formatstr.format(rs2val)  + " # initialize rs2\n"
     lines = lines + "la x" + str(rs1) + ", scratch" + " # base address \n"
     lines = lines + "addi x" + str(rs1) + ", x" + str(rs1) + ", -" + str(int(unsignedImm6(immval))*mul) + " # sub immediate from rs1 to counter offset\n"
-    lines = lines + storeop + " x" + str(rs2) + ", " + str(int(unsignedImm6(immval))*mul) +" (x" + str(rs1) + ") # store value to put something in memory\n"
+    lines = lines + storeop + " x" + str(rs2) + ", " + str(int(unsignedImm6(immval))*mul) +"(x" + str(rs1) + ") # store value to put something in memory\n"
     lines = lines + test + " x" + str(rd) + ", " + str(int(unsignedImm6(immval))*mul) + "(x" + str(rs1) + ") # perform operation\n"
+  elif (test in clhtype or test in clbtype):
+    rd = legalizecompr(rd)
+    rs1 = legalizecompr(rs1)
+    rs2 = legalizecompr(rs2) 
+    while (rs1 == rs2):
+      rs2 = randint(8,15)
+    if (test in clhtype):
+      storeop = "c.sh"
+      mul = 2
+    else:
+      storeop = "c.sb"
+      mul = 1
+    lines = lines + "li x" + str(rs2) + ", " + formatstr.format(rs2val)  + " # initialize rs2\n"
+    lines = lines + "la x" + str(rs1) + ", scratch" + " # base address \n"
+    lines = lines + "addi x" + str(rs1) + ", x" + str(rs1) + ", -" + str(int(unsignedImm1(immval))*mul) + " # sub immediate from rs1 to counter offset\n"
+    lines = lines + storeop + " x" + str(rs2) + ", " + str(int(unsignedImm1(immval))*mul) +"(x" + str(rs1) + ") # store value to put something in memory\n"
+    lines = lines + test + " x" + str(rd) + ", " + str(int(unsignedImm1(immval))*mul) + "(x" + str(rs1) + ") # perform operation\n"
   elif (test in cstype):
     rs1 = legalizecompr(rs1)
     rs2 = legalizecompr(rs2)
@@ -460,7 +477,6 @@ def make_rd_corners(test, xlen, corners):
       desc = "cp_rd_corners (Test rd value = " + hex(v) + ")"
       rs2val = -(rdval - v)
       writeCovVector(desc, rs1, rs2, rd, 0, rs2val, 0, rdval, test, xlen)
-
   else:
     for v in corners:
       # rs1 = 0, rs2 = v, others are random
@@ -933,6 +949,8 @@ if __name__ == '__main__':
   shiftwtype = ["sraiw", "srliw"]
   csbtype = ["c.sb"]
   cshtype = ["c.sh"]
+  clhtype = ["c.lh","c.lhu"]
+  clbtype = ["c.lbu"]
 
   floattypes = frtype + fstype + fltype + fcomptype + F2Xtype + fr4type + fitype + fixtype
   # instructions with all float args

--- a/testplans/RV32Zcb.csv
+++ b/testplans/RV32Zcb.csv
@@ -1,7 +1,7 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_gpr_hazard,cp_rd_corners,cmp_rd_rs1,cmp_rd_rs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rd_corners,cp_rs2_corners,cp_rd_toggle,cp_rs2_toggle,cp_rs1p,cp_rs1_corners,cp_rs1_toggle,cp_fdp,cp_fs2p,cr_rs1_imm_corners
-c.lbu,L,x,,,,,,,,,x,,,,,,,,,,,,,,,,,,,,x,,x,,x,,x,x,x,,
-c.lh,L,x,,,,,,,,,x,,,,,,,,,,,,,,,,,,,,x,,x,,x,,x,x,x,,
-c.lhu,L,x,,,,,,,,,x,,,,,,,,,,,,,,,,,,,,x,,x,,x,,x,x,x,,
+c.lbu,L,x,,,,,,,,,c,,,,,,,,,,,,,,,,,,,,x,,lbu,,lbu,,x,,,,
+c.lh,L,x,,,,,,,,,c,,,,,,,,,,,,,,,,,,,,x,,lh,,x,,x,,,,
+c.lhu,L,x,,,,,,,,,c,,,,,,,,,,,,,,,,,,,,x,,lhu,,lhu,,x,,,,
 c.sb,CSB,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,,x,x,,,,
 c.sh,CSH,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,,x,x,,,,
 c.not,CR1,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,,x,,,,,,

--- a/testplans/RV32Zcb.csv
+++ b/testplans/RV32Zcb.csv
@@ -1,8 +1,8 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_gpr_hazard,cp_rd_corners,cmp_rd_rs1,cmp_rd_rs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rd_corners,cp_rs2_corners,cp_rd_toggle,cp_rs2_toggle,cp_rs1p,cp_rs1_corners,cp_rs1_toggle,cp_fdp,cp_fs2p,cr_rs1_imm_corners
-c.lbu,L,x,,,,,,,,,c,,,,,,,,,,,,,,,,,,,,x,,lbu,,lbu,,x,,,,
-c.lh,L,x,,,,,,,,,c,,,,,,,,,,,,,,,,,,,,x,,lh,,x,,x,,,,
-c.lhu,L,x,,,,,,,,,c,,,,,,,,,,,,,,,,,,,,x,,lhu,,lhu,,x,,,,
+c.lbu,CLB,x,,,,,,,,,c,,,,,,,,,,,,,,,,,,,,x,,lbu,,lbu,,x,,,,
+c.lh,CLH,x,,,,,,,,,c,,,,,,,,,,,,,,,,,,,,x,,lh,,x,,x,,,,
+c.lhu,CLH,x,,,,,,,,,c,,,,,,,,,,,,,,,,,,,,x,,lhu,,lhu,,x,,,,
 c.sb,CSB,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,,x,x,,,,
 c.sh,CSH,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,,x,x,,,,
-c.not,CR1,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,,x,,,,,,
-c.zext.b,CR1,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,,x,,,,,,
+c.not,CU,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,,x,,,,,,
+c.zext.b,CU,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,,x,,,,,,


### PR DESCRIPTION
Excluded cp_rs1_toggle and cp_rs1_corners as rs1 is just a base address. And some templates like cp_rd_toggle_lbu & cp_rd_toggle_lhu were already there. So, I just used that.