### PR TITLE
Near full coverage of fmv.x.w using alias fmv.x.s 

### DIFF
--- a/bin/covergroupgen.py
+++ b/bin/covergroupgen.py
@@ -130,6 +130,9 @@ def customizeTemplate(covergroupTemplates, name, arch, instr):
         template += template.replace(instr, 'neg',1).replace("add_rs1","add_rs1_0",1).replace("add_rs2(2)", "add_rs2(1)")
     if name.startswith('sample_') and instr == 'sltu':
         template += template.replace(instr, 'snez',1).replace("add_rs1","add_rs1_0",1).replace("add_rs2(2)", "add_rs2(1)")
+    # instruction fmv.x.w interpreted by imperas as fmv.x.s (deprecaited names)
+    if name.startswith('sample_') and instr == 'fmv.x.w':
+        template += template.replace(instr, 'fmv.x.s',1)
                 
     return template
 


### PR DESCRIPTION
Hitting 98.87% of bins. 
Only missing asm_count bin, which may not be possible to hit without an imperas fix.
This can be easily extended to other fmv* instructions should they also be aliased to depreciated names. 