### PR TITLE
RV64ZcbZba Done

### DIFF
--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -232,7 +232,7 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
       lines = lines + "li x" + str(rd) + ", " + formatstr.format(rs2val)  + " # initialize rd to specific value\n"
       lines = lines + test + " x" + str(rd) + "  # performing not operation on rd and storing it in same register \n"
       lines = lines + test + " x" + str(rd) + "  # reverting to the prev value, help in covering rd_corners \n"
-    elif test in ["c.zext.b","c.zext.h","c.sext.b","c.sext.h"]:
+    elif test in ["c.zext.b","c.zext.h","c.zext.w","c.sext.b","c.sext.h"]:
       lines = lines + "li x" + str(rd) + ", " + formatstr.format(rs1val) + " # initialize leagalized rd to a random value that should get changed\n"
       lines = lines + test + " x" + str(rd) + " # perform operation\n"
   elif (test in stype):#["sb", "sh", "sw", "sd"]
@@ -965,7 +965,7 @@ if __name__ == '__main__':
   cshtype = ["c.sh"]
   clhtype = ["c.lh","c.lhu"]
   clbtype = ["c.lbu"]
-  cutype = ["c.not", "c.zext.b", "c.zext.h", "c.zext.w","c.sext.b","c.sext.h"]
+  cutype = ["c.not","c.zext.b","c.zext.h","c.zext.w","c.sext.b","c.sext.h"]
 
   floattypes = frtype + fstype + fltype + fcomptype + F2Xtype + fr4type + fitype + fixtype
   # instructions with all float args
@@ -986,7 +986,10 @@ if __name__ == '__main__':
 
   # generate files for each test
   for xlen in xlens:
-    for extension in ["I", "M", "F", "Zicond", "Zca", "Zfh", "Zcb", "ZcbM", "ZcbZbb"]:
+    extensions = ["I", "M", "F", "Zicond", "Zca", "Zfh", "Zcb", "ZcbM", "ZcbZbb"]
+    if (xlen == 64):
+        extensions += ["ZcbZba"]   # Add extensions which are specific to RV64
+    for extension in extensions:
       coverdefdir = WALLY+"/addins/cvw-arch-verif/fcov/rv"+str(xlen)
       coverfiles = ["RV"+str(xlen)+extension] 
       coverpoints = getcovergroups(coverdefdir, coverfiles)

--- a/templates/sample_RV64ZcbZba.txt
+++ b/templates/sample_RV64ZcbZba.txt
@@ -1,0 +1,14 @@
+function void rv64zcbzba_sample(int hart, int issue);
+    ins_rv64zcbzba_t ins;
+    if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
+        $display("Examining compressed instruction rv64zcbzba_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
+        case (traceDataQ[hart][issue][0].inst_name)
+            "zext.w" : begin
+                ins = new(hart, issue, traceDataQ);
+                ins.add_rd(0);       
+                ins.add_rs1(1);     
+                c_zext_w_cg.sample(ins); 
+            end
+        endcase
+    end
+endfunction

--- a/testplans/RV64ZcbZba.csv
+++ b/testplans/RV64ZcbZba.csv
@@ -1,2 +1,2 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_gpr_hazard,cp_rs1_corners,cp_rs2_corners,cr_rs1_rs2_corners,cmp_rd_rs1,cmp_rd_rs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rs1_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rd_corners,cp_rd_toggle,cp_rs2_toggle,cp_rs1p,cp_fdp,cp_fs2p,cr_rs1_imm_corners
-c.zext.w,CR1,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,x,x,,,,,
+c.zext.w,CR1,x,,,,,,,,x,,,,,,,,x,,,,,,x,,,,,,,x,,lwu,lwu,,x,,,


### PR DESCRIPTION
While doing this, I faced a problem. **ZcbZba** is only for RV64, and testgen.py was trying to find RV32 coverage.svh file for it. As it couldn't find it, testgen.py was throwing an error and stopping execution. 
I made a modification in testgen.py, which we can use for extensions that are only made for RV64 or RV32. 