### PR TITLE
Increased coverage for sltiu to 100%

### DIFF
--- a/bin/covergroupgen.py
+++ b/bin/covergroupgen.py
@@ -136,6 +136,8 @@ def customizeTemplate(covergroupTemplates, name, arch, instr):
         template += template.replace(instr, 'neg',1).replace("add_rs1","add_rs1_0",1).replace("add_rs2(2)", "add_rs2(1)")
     if name.startswith('sample_') and instr == 'sltu':
         template += template.replace(instr, 'snez',1).replace("add_rs1","add_rs1_0",1).replace("add_rs2(2)", "add_rs2(1)")
+    if name.startswith('sample_') and instr == 'sltiu': 
+        template += template.replace(instr, 'seqz', 1).replace("add_imm","add_imm_one",1)    
     # instruction fmv.x.w interpreted by imperas as fmv.x.s (deprecaited names)
     if name.startswith('sample_') and instr == 'fmv.x.w':
         template += template.replace(instr, 'fmv.x.s',1)

--- a/fcov/coverage/RISCV_instruction_base.svh
+++ b/fcov/coverage/RISCV_instruction_base.svh
@@ -395,6 +395,10 @@ class RISCV_instruction
         current.imm = get_imm(ops[offset].key);
     endfunction
 
+    virtual function void add_imm_one(int offset);
+        current.imm = 1;
+    endfunction
+
     virtual function void add_imm2(int offset);
         current.imm2 = get_imm(ops[offset].key);
     endfunction


### PR DESCRIPTION
sltiu with immediate value 1 was being replaced with seqz pseudo-instruction, which is resolved now. This improved coverage in both RV32I and RV64I sltiu.