### PR TITLE
Remove Q from march

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,21 +61,21 @@ CMPR_FLAGS = $(ZCA_FLAG)$(ZCB_FLAG)$(ZCD_FLAG)$(ZCF_FLAG)
 
 # Change many things if bit width isn't 64
 $(SRCDIR64)/%.elf: $(SRCDIR64)/%.$(SEXT) 
-	riscv64-unknown-elf-gcc -g -o $@ -march=rv64gq$(CMPR_FLAGS)_zfa_zba_zbb_zbc_zbs_zfh_zicboz_zicbop_zicbom_zicond -mabi=lp64 -mcmodel=medany \
+	riscv64-unknown-elf-gcc -g -o $@ -march=rv64g$(CMPR_FLAGS)_zfa_zba_zbb_zbc_zbs_zfh_zicboz_zicbop_zicbom_zicond -mabi=lp64 -mcmodel=medany \
 	    -nostartfiles -T${WALLY}/examples/link/link.ld $<
 	riscv64-unknown-elf-objdump -S -D $@ > $@.objdump
 	riscv64-unknown-elf-elf2hex --bit-width 64 --input $@ --output $@.memfile
 	extractFunctionRadix.sh $@.objdump
 
 $(SRCDIR32)/%.elf: $(SRCDIR32)/%.$(SEXT) 
-	riscv64-unknown-elf-gcc -g -o $@ -march=rv32gq$(CMPR_FLAGS)_zfa_zba_zbb_zbc_zbs_zfh_zicboz_zicbop_zicbom_zicond -mabi=ilp32 -mcmodel=medany \
+	riscv64-unknown-elf-gcc -g -o $@ -march=rv32g$(CMPR_FLAGS)_zfa_zba_zbb_zbc_zbs_zfh_zicboz_zicbop_zicbom_zicond -mabi=ilp32 -mcmodel=medany \
 	    -nostartfiles -T${WALLY}/examples/link/link.ld $<
 	riscv64-unknown-elf-objdump -S -D $@ > $@.objdump
 	riscv64-unknown-elf-elf2hex --bit-width 32 --input $@ --output $@.memfile
 	extractFunctionRadix.sh $@.objdump
 
 $(SRCDIRPRIV)/%.elf: $(SRCDIRPRIV)/%.$(SEXT) tests/priv/Zicsr-CSR-Tests.h
-	riscv64-unknown-elf-gcc -g -o $@ -march=rv64gq_zfa_zba_zbb_zbc_zbs_zfh_zicboz_zicbop_zicbom_zicond -mabi=lp64 -mcmodel=medany \
+	riscv64-unknown-elf-gcc -g -o $@ -march=rv64g_zfa_zba_zbb_zbc_zbs_zfh_zicboz_zicbop_zicbom_zicond -mabi=lp64 -mcmodel=medany \
 	    -nostartfiles -I${WALLY}/tests/coverage -T${WALLY}/examples/link/link.ld $<
 	riscv64-unknown-elf-objdump -S -D $@ > $@.objdump
 	riscv64-unknown-elf-elf2hex --bit-width 64 --input $@ --output $@.memfile


### PR DESCRIPTION
GCC 14 does not support Q and there are no Q tests currently. If we add Q later we can run the assembler directly.