### PR TITLE
Fixed warnings for compressed instructions

### DIFF
--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -544,22 +544,22 @@ def make_rd(test, xlen, rng):
     desc = "cp_rd (Test destination rd = x" + str(r) + ")"
     writeCovVector(desc, rs1, rs2, r, rs1val, rs2val, immval, rdval, test, xlen)
 
-def make_fd(test, xlen):
-  for r in range(32):
+def make_fd(test, xlen, rng):
+  for r in rng:
     [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
     desc = "cp_fd (Test destination fd = x" + str(r) + ")"
     writeCovVector(desc, rs1, rs2, r, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
-def make_fs1(test, xlen):
-  for r in range(32):
+def make_fs1(test, xlen, rng):
+  for r in rng:
     [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
     while (r == rs2):
       rs2 = randint(1,31)
     desc = "cp_fs1 (Test source fs1 = f" + str(r) + ")"
     writeCovVector(desc, r, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
-def make_fs2(test, xlen):
-  for r in range(32):
+def make_fs2(test, xlen, rng):
+  for r in rng:
     [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
     while (r == rs1):
       rs1 = randint(1,31)
@@ -962,11 +962,17 @@ def write_tests(coverpoints, test, xlen):
     elif (coverpoint == "cp_rs2p"):
       make_rs2(test, xlen, range(8, 16))
     elif (coverpoint == "cp_fd"):
-      make_fd(test, xlen)
+      make_fd(test, xlen, range(32))
+    elif (coverpoint == "cp_fdp"):
+      make_fd(test, xlen, range(8, 16))
     elif (coverpoint == "cp_fs1"):
-      make_fs1(test, xlen)
+      make_fs1(test, xlen, range(32))
+    elif (coverpoint == "cp_fs1p"):
+      make_fs1(test, xlen, range(8, 16))
     elif (coverpoint == "cp_fs2"):
-      make_fs2(test, xlen)
+      make_fs2(test, xlen, range(32))
+    elif (coverpoint == "cp_fs2p"):
+      make_fs2(test, xlen, range(8, 16))
     elif (coverpoint == "cp_fs1_corners"):
       make_fs1_corners(test, xlen, fcorners)
     elif (coverpoint == "cp_fs2_corners"):
@@ -1082,7 +1088,11 @@ def write_tests(coverpoints, test, xlen):
       pass #TODO toggle not needed and seems to be covered by other things
     elif (coverpoint == "cp_rd_toggle"):
       pass #TODO toggle not needed and seems to be covered by other things
+    elif (coverpoint[:13] == "cp_rd_toggle_" and coverpoint[13:] in ["clui", "slli", "srli", "auipc", "lwu", "lhu", "lbu"]):
+      pass #TODO toggle not needed and seems to be covered by other things
     elif (coverpoint == "cp_fd_toggle"):
+      pass #TODO toggle not needed and seems to be covered by other things
+    elif (coverpoint == "cp_fs2_toggle"):
       pass #TODO toggle not needed and seems to be covered by other things
     elif (coverpoint == "cp_fd_toggle_lw"):
       pass #TODO toggle not needed and seems to be covered by other things
@@ -1098,6 +1108,8 @@ def write_tests(coverpoints, test, xlen):
       #cover point for jalr would still pass since it is getting covered by other instructions. But still testing it for satisfaction.
       if (test == "jalr"): 
         make_jalr_imm_ones_zeros(test, xlen)
+    elif (coverpoint == "cp_imm_ones_zeros_addi4spn"):
+       pass # not needed and seems to be covered by other things
     elif (coverpoint == "cp_imm_ones_zeros_c_jal"):
         make_j_imm_ones_zeros(test,xlen)
     elif (coverpoint == "cp_mem_hazard"):
@@ -1116,12 +1128,6 @@ def write_tests(coverpoints, test, xlen):
       make_imm_shift(test, xlen)
     elif coverpoint in ["cp_imm_mul","cp_imm_mul_8","cp_imm_mul_addi4spn","cp_imm_mul_addi16sp","cp_imm_mul_4sp","cp_imm_mul_8sp"]:
       make_imm_mul(test, xlen)
-    elif (coverpoint == "cp_fd"):
-      make_fd(test, xlen)
-    elif (coverpoint == "cp_fs1"):
-      make_fs1(test, xlen)
-    elif (coverpoint == "cp_fs2"):
-      make_fs2(test, xlen)
     elif (coverpoint == "cp_fs3"):
       make_fs3(test, xlen)
     elif (coverpoint == "cp_rd_boolean"):

--- a/templates/sample_RV32ZcbM.txt
+++ b/templates/sample_RV32ZcbM.txt
@@ -3,7 +3,7 @@ function void rv32zcbm_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv32zcbm_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "mul" : begin
+            "mul"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[15:10] == 6'b100111) begin // Specific bits for "mul" 
                     ins = new(hart, issue, traceDataQ); 
                     ins.add_rd(0);                 

--- a/templates/sample_RV32ZcbZbb.txt
+++ b/templates/sample_RV32ZcbZbb.txt
@@ -3,7 +3,7 @@ function void rv32zcbzbb_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv32zcbzbb_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "sext.b" : begin
+            "sext.b"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[6:2] == 5'b11001) begin // Specific bits for "c.sext.b"
                     ins = new(hart, issue, traceDataQ);
                     ins.add_rd(0);
@@ -11,7 +11,7 @@ function void rv32zcbzbb_sample(int hart, int issue);
                     c_sext_b_cg.sample(ins); 
                 end
             end
-            "zext.h" : begin
+            "zext.h"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[6:2] == 5'b11010) begin // Specific bits for "c.zext.h"
                     ins = new(hart, issue, traceDataQ);
                     ins.add_rd(0); 
@@ -19,7 +19,7 @@ function void rv32zcbzbb_sample(int hart, int issue);
                     c_zext_h_cg.sample(ins); 
                 end
             end
-            "sext.h" : begin
+            "sext.h"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[6:2] == 5'b11011) begin // Specific bits for "c.sext.h"
                     ins = new(hart, issue, traceDataQ);
                     ins.add_rd(0); 

--- a/templates/sample_RV32Zcf.txt
+++ b/templates/sample_RV32Zcf.txt
@@ -4,7 +4,7 @@ function void rv32zcf_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv32zcf_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "flw" : begin
+            "flw"     : begin
                 ins = new(hart, issue, traceDataQ);
                 ins.add_fd(0); 
                 ins.add_imm(1);
@@ -12,7 +12,7 @@ function void rv32zcf_sample(int hart, int issue);
                 ins.add_mem_address(); 
                 c_flw_cg.sample(ins); 
             end
-            "fsw" : begin
+            "fsw"     : begin
                 ins = new(hart, issue, traceDataQ);
                 ins.add_fs2(0);
                 ins.add_imm(1); 

--- a/templates/sample_RV64ZcbM.txt
+++ b/templates/sample_RV64ZcbM.txt
@@ -3,7 +3,7 @@ function void rv64zcbm_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv64zcbm_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "mul" : begin
+            "mul"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[15:10] == 6'b100111) begin // Specific bits for "mul" 
                     ins = new(hart, issue, traceDataQ); 
                     ins.add_rd(0);                  

--- a/templates/sample_RV64ZcbZba.txt
+++ b/templates/sample_RV64ZcbZba.txt
@@ -3,7 +3,7 @@ function void rv64zcbzba_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv64zcbzba_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "zext.w" : begin
+            "zext.w"     : begin
                 ins = new(hart, issue, traceDataQ);
                 ins.add_rd(0);       
                 ins.add_rs1(1);     

--- a/templates/sample_RV64ZcbZbb.txt
+++ b/templates/sample_RV64ZcbZbb.txt
@@ -3,7 +3,7 @@ function void rv64zcbzbb_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv64zcbzbb_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "sext.b" : begin
+            "sext.b"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[6:2] == 5'b11001) begin // Specific bits for "sext.b"
                     ins = new(hart, issue, traceDataQ);
                     ins.add_rd(0);      
@@ -11,7 +11,7 @@ function void rv64zcbzbb_sample(int hart, int issue);
                     c_sext_b_cg.sample(ins); 
                 end
             end
-            "zext.h" : begin
+            "zext.h"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[6:2] == 5'b11010) begin // Specific bits for "zext.h"
                     ins = new(hart, issue, traceDataQ);
                     ins.add_rd(0);       
@@ -19,7 +19,7 @@ function void rv64zcbzbb_sample(int hart, int issue);
                     c_zext_h_cg.sample(ins); 
                 end
             end
-            "sext.h" : begin
+            "sext.h"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[6:2] == 5'b11011) begin // Specific bits for "sext.h"
                     ins = new(hart, issue, traceDataQ);
                     ins.add_rd(0);       


### PR DESCRIPTION
Some coverpoints that did not require specific test generation were not mentioned in testgen.py. It was causing warnings.
Also, sample templates for Zcb, ZcbZbb, ZcbZba & Zcf lacked proper spacing between **instruction name** and '**:**', due to which the instruction name was being misinterpreted as a coverpoint.
Added support for fdp, fs1p and fs2p.

About 30 warnings have been suppressed.