### PR TITLE
FLI immediate coverpoint

### DIFF
--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -582,14 +582,12 @@ def make_fd(test, xlen, rng):
     desc = "cp_fd (Test destination fd = x" + str(r) + ")"
     writeCovVector(desc, rs1, rs2, r, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
-def make_fs1(test, xlen, rng, fli=False):
+def make_fs1(test, xlen, rng):
   for r in rng:
     [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
     while (r == rs2):
       rs2 = randint(1,31)
     desc = "cp_fs1 (Test source fs1 = f" + str(r) + ")"
-    if fli:
-      desc = f"cp_rs1_fli (Immediate = {flivals[r]} with fs1 encoding 5'b{format(r, f'05b')})"
     writeCovVector(desc, r, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
 def make_fs2(test, xlen, rng):
@@ -600,10 +598,12 @@ def make_fs2(test, xlen, rng):
     desc = "cp_fs2 (Test source fs2 = f" + str(r) + ")"
     writeCovVector(desc, rs1, r, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
-def make_rs1(test, xlen, rng = range(32)):
+def make_rs1(test, xlen, rng = range(32), fli=False):
   for r in rng:
     [rs1, rs2, rd, rs1val, rs2val, immval, rdval] = randomize(rs1=r, allunique=True)
     desc = "cp_rs1 (Test source rs1 = x" + str(r) + ")"
+    if fli:
+      desc = f"cp_rs1_fli (Immediate = {flivals[r]} with rs1 encoding 5'b{format(r, f'05b')})"
     writeCovVector(desc, r, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen)
 
 def make_rs2(test, xlen, rng = range(32)):
@@ -1210,7 +1210,7 @@ def write_tests(coverpoints, test, xlen):
     elif (coverpoint == "cp_csr_frm"):
       pass # already covered by cp_frm tests
     elif (coverpoint == "cp_rs1_fli"):
-      make_fs1(test, xlen, range(32), fli=True)
+      make_rs1(test, xlen, range(32), fli=True)
     else:
       print("Warning: " + coverpoint + " not implemented yet for " + test)
       

--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -589,7 +589,7 @@ def make_fs1(test, xlen, rng, fli=False):
       rs2 = randint(1,31)
     desc = "cp_fs1 (Test source fs1 = f" + str(r) + ")"
     if fli:
-      desc = f"cp_fs1_fli (Immediate = {flivals[r]} with fs1 encoding 5'b{format(r, f'05b')})"
+      desc = f"cp_rs1_fli (Immediate = {flivals[r]} with fs1 encoding 5'b{format(r, f'05b')})"
     writeCovVector(desc, r, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
 def make_fs2(test, xlen, rng):
@@ -1209,7 +1209,7 @@ def write_tests(coverpoints, test, xlen):
       pass # doesn't require designated tests
     elif (coverpoint == "cp_csr_frm"):
       pass # already covered by cp_frm tests
-    elif (coverpoint == "cp_fs1_fli"):
+    elif (coverpoint == "cp_rs1_fli"):
       make_fs1(test, xlen, range(32), fli=True)
     else:
       print("Warning: " + coverpoint + " not implemented yet for " + test)

--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -570,12 +570,14 @@ def make_fd(test, xlen, rng):
     desc = "cp_fd (Test destination fd = x" + str(r) + ")"
     writeCovVector(desc, rs1, rs2, r, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
-def make_fs1(test, xlen, rng):
+def make_fs1(test, xlen, rng, fli=False):
   for r in rng:
     [rs1, rs2, rs3, rd, rs1val, rs2val, rs3val, immval, rdval] = randomize(rs3=True)
     while (r == rs2):
       rs2 = randint(1,31)
     desc = "cp_fs1 (Test source fs1 = f" + str(r) + ")"
+    if fli:
+      desc = f"cp_fs1_fli (Immediate = {flivals[r]} with fs1 encoding 5'b{format(r, f'05b')})"
     writeCovVector(desc, r, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=rs3, rs3val=rs3val)
 
 def make_fs2(test, xlen, rng):
@@ -1195,7 +1197,8 @@ def write_tests(coverpoints, test, xlen):
       pass # doesn't require designated tests
     elif (coverpoint == "cp_csr_frm"):
       pass # already covered by cp_frm tests
-      
+    elif (coverpoint == "cp_fs1_fli"):
+      make_fs1(test, xlen, range(32), fli=True)
     else:
       print("Warning: " + coverpoint + " not implemented yet for " + test)
       
@@ -1297,7 +1300,7 @@ if __name__ == '__main__':
   cutype = ["c.not","c.zext.b","c.zext.h","c.zext.w","c.sext.b","c.sext.h"]
   zcftype = ["c.flw", "c.fsw"] # Zcf instructions
   zcdtype = ["c.fld", "c.fsd"]
-  flitype = [] # ["fli.s", "fli.h", "fli.d"] # technically FI type but with a strange "immediate" encoding, need special cases 
+  flitype = ["fli.s", "fli.h", "fli.d"] # technically FI type but with a strange "immediate" encoding, need special cases 
   #                 ^~~~~~~~~~~~~~~~~~~~~~~~ TODO: restore fli type instructions after creating new sample function
   floattypes = frtype + fstype + fltype + fcomptype + F2Xtype + fr4type + fitype + fixtype + X2Ftype + zcftype + flitype + PX2Ftype + zcdtype
   # instructions with all float args

--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -1313,7 +1313,6 @@ if __name__ == '__main__':
   zcftype = ["c.flw", "c.fsw"] # Zcf instructions
   zcdtype = ["c.fld", "c.fsd"]
   flitype = ["fli.s", "fli.h", "fli.d"] # technically FI type but with a strange "immediate" encoding, need special cases 
-  #                 ^~~~~~~~~~~~~~~~~~~~~~~~ TODO: restore fli type instructions after creating new sample function
   floattypes = frtype + fstype + fltype + fcomptype + F2Xtype + fr4type + fitype + fixtype + X2Ftype + zcftype + flitype + PX2Ftype + zcdtype
   # instructions with all float args
   regconfig_ffff = frtype + fr4type + fitype + flitype

--- a/templates/cp_fs1_fli.txt
+++ b/templates/cp_fs1_fli.txt
@@ -1,3 +1,0 @@
-    cp_fs1_fli : coverpoint ins.current.insn[19:15]  iff (ins.trap == 0 )  {
-        option.comment = "FLI immediate encoding";
-    }

--- a/templates/cp_fs1_fli.txt
+++ b/templates/cp_fs1_fli.txt
@@ -1,0 +1,3 @@
+    cp_fs1_fli : coverpoint ins.current.insn[19:15]  iff (ins.trap == 0 )  {
+        option.comment = "FLI immediate encoding";
+    }

--- a/templates/cp_rs1_fli.txt
+++ b/templates/cp_rs1_fli.txt
@@ -1,0 +1,3 @@
+    cp_rs1_fli : coverpoint ins.current.insn[19:15]  iff (ins.trap == 0 )  {
+        option.comment = "FLI immediate encoding";
+    }

--- a/testplans/RV32ZfaD.csv
+++ b/testplans/RV32ZfaD.csv
@@ -1,5 +1,5 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_fpr_hazard,cp_rd_corners,cp_rs1_corners,cp_rs2_corners,cr_rs1_rs2_corners,cmp_fd_fs1,cmp_fd_fs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2_sign,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rs1p,cp_fdp,cp_fs2p,cr_rs1_imm_corners,cp_bs,cp_rnum,cp_sc,cbo***,cp_csr_fflags,cp_csr_frm,cp_fs1_corners,cp_fs2_corners,cp_fs3_corners,cp_frm,cr_fs1_fs2_corners,cr_fs1_fs3_corners,cp_fclass,cp_fd,cp_fs1,cp_fs2,cp_fmemhazard,cp_fd_toggle,cp_gpr_hazard,cmp_fs1_fs3,cr_fs1_corners
-fli.d,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,fli,,,,,,
+fli.d,FI,x,,fli,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,,,,,,
 fminm.d,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,D,D,,,D,,,x,x,x,,,,,
 fmaxm.d,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,D,D,,,D,,,x,x,x,,,,,
 fround.d,FI,x,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,x,D,,,2,,,,x,x,,,,,,frm_D

--- a/testplans/RV32ZfaD.csv
+++ b/testplans/RV32ZfaD.csv
@@ -1,5 +1,5 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_fpr_hazard,cp_rd_corners,cp_rs1_corners,cp_rs2_corners,cr_rs1_rs2_corners,cmp_fd_fs1,cmp_fd_fs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2_sign,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rs1p,cp_fdp,cp_fs2p,cr_rs1_imm_corners,cp_bs,cp_rnum,cp_sc,cbo***,cp_csr_fflags,cp_csr_frm,cp_fs1_corners,cp_fs2_corners,cp_fs3_corners,cp_frm,cr_fs1_fs2_corners,cr_fs1_fs3_corners,cp_fclass,cp_fd,cp_fs1,cp_fs2,cp_fmemhazard,cp_fd_toggle,cp_gpr_hazard,cmp_fs1_fs3,cr_fs1_corners
-fli.d,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,,,,,,
+fli.d,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,fli,,,,,,
 fminm.d,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,D,D,,,D,,,x,x,x,,,,,
 fmaxm.d,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,D,D,,,D,,,x,x,x,,,,,
 fround.d,FI,x,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,x,D,,,2,,,,x,x,,,,,,frm_D

--- a/testplans/RV32ZfaF.csv
+++ b/testplans/RV32ZfaF.csv
@@ -1,5 +1,5 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_fpr_hazard,cp_rd_corners,cp_rs1_corners,cp_rs2_corners,cr_rs1_rs2_corners,cmp_fd_fs1,cmp_fd_fs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2_sign,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rs1p,cp_fdp,cp_fs2p,cr_rs1_imm_corners,cp_bs,cp_rnum,cp_sc,cbo***,cp_csr_fflags,cp_csr_frm,cp_fs1_corners,cp_fs2_corners,cp_fs3_corners,cp_frm,cr_fs1_fs2_corners,cr_fs1_fs3_corners,cp_fclass,cp_fd,cp_fs1,cp_fs2,cp_fmemhazard,cp_fd_toggle,cp_gpr_hazard,cmp_fs1_fs3,cr_fs1_corners
-fli.s,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,,,,,,
+fli.s,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,fli,,,,,,
 fminm.s,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,x,x,,,x,,,x,x,x,,,,,
 fmaxm.s,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,x,x,,,x,,,x,x,x,,,,,
 fround.s,FI,x,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,x,x,,,2,,,,x,x,,,,,,frm

--- a/testplans/RV32ZfaF.csv
+++ b/testplans/RV32ZfaF.csv
@@ -1,5 +1,5 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_fpr_hazard,cp_rd_corners,cp_rs1_corners,cp_rs2_corners,cr_rs1_rs2_corners,cmp_fd_fs1,cmp_fd_fs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2_sign,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rs1p,cp_fdp,cp_fs2p,cr_rs1_imm_corners,cp_bs,cp_rnum,cp_sc,cbo***,cp_csr_fflags,cp_csr_frm,cp_fs1_corners,cp_fs2_corners,cp_fs3_corners,cp_frm,cr_fs1_fs2_corners,cr_fs1_fs3_corners,cp_fclass,cp_fd,cp_fs1,cp_fs2,cp_fmemhazard,cp_fd_toggle,cp_gpr_hazard,cmp_fs1_fs3,cr_fs1_corners
-fli.s,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,fli,,,,,,
+fli.s,FI,x,,fli,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,,,,,,
 fminm.s,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,x,x,,,x,,,x,x,x,,,,,
 fmaxm.s,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,x,x,,,x,,,x,x,x,,,,,
 fround.s,FI,x,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,x,x,,,2,,,,x,x,,,,,,frm

--- a/testplans/RV32ZfaZfh.csv
+++ b/testplans/RV32ZfaZfh.csv
@@ -1,5 +1,5 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_fpr_hazard,cp_rd_corners,cp_rs1_corners,cp_rs2_corners,cr_rs1_rs2_corners,cmp_fd_fs1,cmp_fd_fs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2_sign,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rs1p,cp_fdp,cp_fs2p,cr_rs1_imm_corners,cp_bs,cp_rnum,cp_sc,cbo***,cp_csr_fflags,cp_csr_frm,cp_fs1_corners,cp_fs2_corners,cp_fs3_corners,cp_frm,cr_fs1_fs2_corners,cr_fs1_fs3_corners,cp_fclass,cp_fd,cp_fs1,cp_fs2,cp_fmemhazard,cp_fd_toggle,cp_gpr_hazard,cmp_fs1_fs3,cr_fs1_corners
-fli.h,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,,,,,,
+fli.h,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,fli,,,,,,
 fminm.h,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,H,H,,,H,,,x,x,x,,,,,
 fmaxm.h,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,H,H,,,H,,,x,x,x,,,,,
 fround.h,FI,x,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,x,H,,,2,,,,x,x,,,,,,frm_H

--- a/testplans/RV32ZfaZfh.csv
+++ b/testplans/RV32ZfaZfh.csv
@@ -1,5 +1,5 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_fpr_hazard,cp_rd_corners,cp_rs1_corners,cp_rs2_corners,cr_rs1_rs2_corners,cmp_fd_fs1,cmp_fd_fs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2_sign,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rs1p,cp_fdp,cp_fs2p,cr_rs1_imm_corners,cp_bs,cp_rnum,cp_sc,cbo***,cp_csr_fflags,cp_csr_frm,cp_fs1_corners,cp_fs2_corners,cp_fs3_corners,cp_frm,cr_fs1_fs2_corners,cr_fs1_fs3_corners,cp_fclass,cp_fd,cp_fs1,cp_fs2,cp_fmemhazard,cp_fd_toggle,cp_gpr_hazard,cmp_fs1_fs3,cr_fs1_corners
-fli.h,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,fli,,,,,,
+fli.h,FI,x,,fli,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,,,,,,
 fminm.h,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,H,H,,,H,,,x,x,x,,,,,
 fmaxm.h,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,H,H,,,H,,,x,x,x,,,,,
 fround.h,FI,x,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,x,H,,,2,,,,x,x,,,,,,frm_H

--- a/testplans/RV64ZfaD.csv
+++ b/testplans/RV64ZfaD.csv
@@ -1,5 +1,5 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_fpr_hazard,cp_rd_corners,cp_rs1_corners,cp_rs2_corners,cr_rs1_rs2_corners,cmp_fd_fs1,cmp_fd_fs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2_sign,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rs1p,cp_fdp,cp_fs2p,cr_rs1_imm_corners,cp_bs,cp_rnum,cp_sc,cbo***,cp_csr_fflags,cp_csr_frm,cp_fs1_corners,cp_fs2_corners,cp_fs3_corners,cp_frm,cr_fs1_fs2_corners,cr_fs1_fs3_corners,cp_fclass,cp_fd,cp_fs1,cp_fs2,cp_fmemhazard,cp_fd_toggle,cp_gpr_hazard,cmp_fs1_fs3,cr_fs1_corners
-fli.d,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,fli,,,,,,
+fli.d,FI,x,,fli,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,,,,,,
 fminm.d,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,D,D,,,D,,,x,x,x,,,,,
 fmaxm.d,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,D,D,,,D,,,x,x,x,,,,,
 fround.d,FI,x,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,x,D,,,2,,,,x,x,,,,,,frm_D

--- a/testplans/RV64ZfaD.csv
+++ b/testplans/RV64ZfaD.csv
@@ -1,5 +1,5 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_fpr_hazard,cp_rd_corners,cp_rs1_corners,cp_rs2_corners,cr_rs1_rs2_corners,cmp_fd_fs1,cmp_fd_fs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2_sign,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rs1p,cp_fdp,cp_fs2p,cr_rs1_imm_corners,cp_bs,cp_rnum,cp_sc,cbo***,cp_csr_fflags,cp_csr_frm,cp_fs1_corners,cp_fs2_corners,cp_fs3_corners,cp_frm,cr_fs1_fs2_corners,cr_fs1_fs3_corners,cp_fclass,cp_fd,cp_fs1,cp_fs2,cp_fmemhazard,cp_fd_toggle,cp_gpr_hazard,cmp_fs1_fs3,cr_fs1_corners
-fli.d,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,,,,,,
+fli.d,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,fli,,,,,,
 fminm.d,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,D,D,,,D,,,x,x,x,,,,,
 fmaxm.d,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,D,D,,,D,,,x,x,x,,,,,
 fround.d,FI,x,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,x,D,,,2,,,,x,x,,,,,,frm_D

--- a/testplans/RV64ZfaF.csv
+++ b/testplans/RV64ZfaF.csv
@@ -1,5 +1,5 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_fpr_hazard,cp_rd_corners,cp_rs1_corners,cp_rs2_corners,cr_rs1_rs2_corners,cmp_fd_fs1,cmp_fd_fs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2_sign,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rs1p,cp_fdp,cp_fs2p,cr_rs1_imm_corners,cp_bs,cp_rnum,cp_sc,cbo***,cp_csr_fflags,cp_csr_frm,cp_fs1_corners,cp_fs2_corners,cp_fs3_corners,cp_frm,cr_fs1_fs2_corners,cr_fs1_fs3_corners,cp_fclass,cp_fd,cp_fs1,cp_fs2,cp_fmemhazard,cp_fd_toggle,cp_gpr_hazard,cmp_fs1_fs3,cr_fs1_corners
-fli.s,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,,,,,,
+fli.s,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,fli,,,,,,
 fminm.s,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,x,x,,,x,,,x,x,x,,,,,
 fmaxm.s,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,x,x,,,x,,,x,x,x,,,,,
 fround.s,FI,x,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,x,x,,,2,,,,x,x,,,,,,frm

--- a/testplans/RV64ZfaF.csv
+++ b/testplans/RV64ZfaF.csv
@@ -1,5 +1,5 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_fpr_hazard,cp_rd_corners,cp_rs1_corners,cp_rs2_corners,cr_rs1_rs2_corners,cmp_fd_fs1,cmp_fd_fs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2_sign,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rs1p,cp_fdp,cp_fs2p,cr_rs1_imm_corners,cp_bs,cp_rnum,cp_sc,cbo***,cp_csr_fflags,cp_csr_frm,cp_fs1_corners,cp_fs2_corners,cp_fs3_corners,cp_frm,cr_fs1_fs2_corners,cr_fs1_fs3_corners,cp_fclass,cp_fd,cp_fs1,cp_fs2,cp_fmemhazard,cp_fd_toggle,cp_gpr_hazard,cmp_fs1_fs3,cr_fs1_corners
-fli.s,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,fli,,,,,,
+fli.s,FI,x,,fli,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,,,,,,
 fminm.s,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,x,x,,,x,,,x,x,x,,,,,
 fmaxm.s,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,x,x,,,x,,,x,x,x,,,,,
 fround.s,FI,x,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,x,x,,,2,,,,x,x,,,,,,frm

--- a/testplans/RV64ZfaZfh.csv
+++ b/testplans/RV64ZfaZfh.csv
@@ -1,5 +1,5 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_fpr_hazard,cp_rd_corners,cp_rs1_corners,cp_rs2_corners,cr_rs1_rs2_corners,cmp_fd_fs1,cmp_fd_fs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2_sign,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rs1p,cp_fdp,cp_fs2p,cr_rs1_imm_corners,cp_bs,cp_rnum,cp_sc,cbo***,cp_csr_fflags,cp_csr_frm,cp_fs1_corners,cp_fs2_corners,cp_fs3_corners,cp_frm,cr_fs1_fs2_corners,cr_fs1_fs3_corners,cp_fclass,cp_fd,cp_fs1,cp_fs2,cp_fmemhazard,cp_fd_toggle,cp_gpr_hazard,cmp_fs1_fs3,cr_fs1_corners
-fli.h,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,x,,,,,,
+fli.h,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,fli,,,,,,
 fminm.h,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,H,H,,,H,,,x,x,x,,,,,
 fmaxm.h,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,H,H,,,H,,,x,x,x,,,,,
 fround.h,FI,x,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,x,H,,,2,,,,x,x,,,,,,frm_H

--- a/testplans/RV64ZfaZfh.csv
+++ b/testplans/RV64ZfaZfh.csv
@@ -1,5 +1,5 @@
 Instruction,Type,cp_asm_count,cp_rd,cp_rs1,cp_rs2,cmp_rd_rs1_eqval,cmp_rd_rs2_eqval,cmp_rs1_rs2_eqval,cp_fpr_hazard,cp_rd_corners,cp_rs1_corners,cp_rs2_corners,cr_rs1_rs2_corners,cmp_fd_fs1,cmp_fd_fs2,cmp_rd_rs1_rs2,cmp_rs1_rs2,cp_rd_sign,cp_rs1_sign,cp_rs2_sign,cr_rs1_rs2_sign,cp_offset,cp_imm_sign,cr_rs1_imm,cp_rd_toggle,cp_rs1_toggle,cp_rs2_toggle,cp_imm_ones_zeros,cp_imm_zero,cp_memhazard,cp_memunaligned,cp_rd_boolean,cp_imm_shift,cp_rdp,cp_rs2p,cp_rs1p,cp_fdp,cp_fs2p,cr_rs1_imm_corners,cp_bs,cp_rnum,cp_sc,cbo***,cp_csr_fflags,cp_csr_frm,cp_fs1_corners,cp_fs2_corners,cp_fs3_corners,cp_frm,cr_fs1_fs2_corners,cr_fs1_fs3_corners,cp_fclass,cp_fd,cp_fs1,cp_fs2,cp_fmemhazard,cp_fd_toggle,cp_gpr_hazard,cmp_fs1_fs3,cr_fs1_corners
-fli.h,FI,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,fli,,,,,,
+fli.h,FI,x,,fli,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,x,,,,,,,
 fminm.h,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,H,H,,,H,,,x,x,x,,,,,
 fmaxm.h,FR,x,,,,,,,x,,,,,x,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,,H,H,,,H,,,x,x,x,,,,,
 fround.h,FI,x,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,v,x,H,,,2,,,,x,x,,,,,,frm_H


### PR DESCRIPTION
* Created new coverpoint that checks the 5 bits of the rs1 field in the instruction binary, making sure each of the 32 values is exercised
* All FLI instructions are getting majority (87.5%) coverage, only missing hazard coverpoints
* FLI instructions should be fully covered once hazard refactoring is completed by the HMC team