### PR TITLE
We covered divuw and divw for RV64M to 100 percent coverage

### DIFF
--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -708,6 +708,13 @@ def make_rd_corners(test, xlen, corners):
       rdval = v - immval
       rdval &= 0xFFFFFFFFFFFFFFFF   # This prevents -ve decimal rdval (converts -10 to 18446744073709551606)
       writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen)
+  
+  elif (test == "divw" or test == "divuw"):
+    for v in corners:
+      desc = "cp_rd_corners (Test rd value = " + hex(v) + ")"
+      [rs1, rs2, rd, rs1val, rs2val, immval, rdval] = randomize()
+      writeCovVector(desc, rs1, rs2, rd, v, 1, v, rdval, test, xlen)
+      
   elif (test == "c.lui"):
     for v in corners:
       desc = "cp_rd_corners (Test rd value = " + hex(v) + ")"


### PR DESCRIPTION
We have covered  divw and divuw by adding an elif statement for both of the cases to set the value of rs2 to be 1 so that our testcases all of them hit. The changes were made in testgen.py