### PR TITLE
Enabled 'c' prefix for compressed instructions

### DIFF
--- a/bin/covergroupgen.py
+++ b/bin/covergroupgen.py
@@ -84,18 +84,10 @@ def customizeTemplate(covergroupTemplates, name, arch, instr):
         return ""
     instr_nodot = instr.replace(".", "_")
     template = template.replace("INSTRNODOT", instr_nodot)
-    # Compressed instrs get passed to covergroups as 'c.li' -> 'li', 'c.addi16sp' -> 'addi'.
-    # This makes sure that cp_asm_count gets hit
-    c_instr_alias = {"c.addi16sp":"addi", "c.addi4spn":"addi", "c.nop":"addi","c.lwsp":"lw","c.ldsp":"ld","c.swsp":"sw","c.sdsp":"sd","c.flwsp":"flw","c.fswsp":"fsw","c.fsdsp":"fsd","c.fldsp":"fld"}
     # special cases for fmv instructions being interpreted with depreciated names
     # we need to look for the old name for asm_count
     fmv_instr_alias = {"fmv.x.w":"fmv.x.s", "fmv.w.x":"fmv.s.x"}
-    if (name == "cp_asm_count" and instr.startswith("c.")):
-        if (instr in c_instr_alias):
-            template = template.replace("INSTR", c_instr_alias[instr])
-        else:
-            template = template.replace("INSTR", instr[2:]) # Just strip 'c.'
-    elif (name == "cp_asm_count" and instr in fmv_instr_alias):
+    if (name == "cp_asm_count" and instr in fmv_instr_alias):
             template = template.replace("INSTR", fmv_instr_alias[instr])
     else:
         template = template.replace("INSTR", instr)

--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -1246,21 +1246,16 @@ def getcovergroups(coverdefdir, coverfiles):
   for coverfile in coverfiles:
     coverfile = coverdefdir + "/" + coverfile + "_coverage.svh"
     f = open(coverfile, "r")
-    prev_line = "" 
     for line in f:
       m = re.search(r'cp_asm_count.*\"(.*)"', line)
       if (m):
 #        if (curinstr != ""):
 #          print(curinstr + ": " + str(coverpoints[curinstr]))
         curinstr = m.group(1)
-        #  If in a Zc* dir, curinstr name is on previous line
-        if (re.search(r'/RV..Zc.+_coverage', coverfile)):
-          curinstr = re.search(r'option.comment = "(.*)"', prev_line).group(1)
         coverpoints[curinstr] = []
       m = re.search("\s*(\S+) :", line)
       if (m):
         coverpoints[curinstr].append(m.group(1))
-      prev_line = line # Store for next iteration
     f.close()
     print(coverpoints)
     return coverpoints

--- a/templates/sample_RV32Zca.txt
+++ b/templates/sample_RV32Zca.txt
@@ -4,176 +4,177 @@ function void rv32zca_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv32zca_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            // Distinguish among the four types of addi compressed instructions
-            "addi"     : begin 
-                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00 & traceDataQ[hart][issue][0].insn[15:13] == 3'b000) begin // addi4spn
+            // Distinguish among "c.add" and "c.nop"
+            "c.addi"     : begin 
+                if (traceDataQ[hart][issue][0].insn[15:0] == 1) begin   // c.nop
                     ins = new(hart, issue, traceDataQ); 
-                    ins.add_rd(0);
-                    ins.add_rs1(1);
-                    ins.add_imm(2);
-                    c_addi4spn_cg.sample(ins); 
-                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 & traceDataQ[hart][issue][0].insn[15:13] == 3'b011) begin // addi16sp
-                    ins = new(hart, issue, traceDataQ); 
-                    ins.add_rd(0);
-                    ins.add_imm(2);
-                    c_addi16sp_cg.sample(ins); 
-                end else if (traceDataQ[hart][issue][0].insn[15:1] == 0) begin // nop
-                    ins = new(hart, issue, traceDataQ); 
+                    ins.ins_str = "c.nop";  // Using correct inst name (c.nop instead of c.addi)
                     c_nop_cg.sample(ins); 
-                end else begin // ordinary addi
+                end else begin      // c.addi
                     ins = new(hart, issue, traceDataQ); 
                     ins.add_rd(0);
-                    ins.add_imm(2);
+                    ins.add_imm(1);
                     c_addi_cg.sample(ins); 
                 end
             end
-            "lw"     : begin 
-                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00 & traceDataQ[hart][issue][0].insn[15:13] == 3'b010) begin // normal lw
-                    ins = new(hart, issue, traceDataQ); 
-                    ins.add_rd(0);
-                    ins.add_imm(1);
-                    ins.add_rs1(2);
-                    ins.current.inst_category = INST_CAT_LOAD;
-                    ins.add_mem_address();
-                    c_lw_cg.sample(ins); 
-                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b10 & traceDataQ[hart][issue][0].insn[15:13] == 3'b010) begin // lwsp
-                    ins = new(hart, issue, traceDataQ); 
-                    ins.add_rd(0);
-                    ins.add_imm(1);
-                    ins.add_rs1_2();
-                    ins.current.inst_category = INST_CAT_LOAD;
-                    ins.add_mem_address();
-                    c_lwsp_cg.sample(ins); 
-                end 
+            "c.addi4spn"     : begin   
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_rs1(1);
+                ins.add_imm(2);
+                c_addi4spn_cg.sample(ins); 
+            end 
+            "c.addi16sp"     : begin         
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_imm(1);
+                c_addi16sp_cg.sample(ins); 
+            end 
+            "c.lw"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_imm(1);
+                ins.add_rs1(2);
+                ins.current.inst_category = INST_CAT_LOAD;
+                ins.add_mem_address();
+                c_lw_cg.sample(ins);
             end
-            "sw"     : begin 
-                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00 & traceDataQ[hart][issue][0].insn[15:13] == 3'b110) begin // normal sw
-                    ins = new(hart, issue, traceDataQ); 
-                    ins.add_rs2(0);
-                    ins.add_imm(1);
-                    ins.add_rs1(2);
-                    ins.current.inst_category = INST_CAT_STORE;
-                    ins.add_mem_address();
-                    c_sw_cg.sample(ins); 
-                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b10 & traceDataQ[hart][issue][0].insn[15:13] == 3'b110) begin // swsp
-                    ins = new(hart, issue, traceDataQ); 
-                    ins.add_rs2(0);
-                    ins.add_imm(1);
-                    ins.add_rs1_2();
-                    ins.current.inst_category = INST_CAT_STORE;
-                    ins.add_mem_address();
-                    c_swsp_cg.sample(ins); 
-                end 
+            "c.lwsp"     : begin  
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_imm(1);
+                ins.add_rs1_2();
+                ins.current.inst_category = INST_CAT_LOAD;
+                ins.add_mem_address();
+                c_lwsp_cg.sample(ins); 
             end
-            "li"     : begin 
+            "c.sw"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rs2(0);
+                ins.add_imm(1);
+                ins.add_rs1(2);
+                ins.current.inst_category = INST_CAT_STORE;
+                ins.add_mem_address();
+                c_sw_cg.sample(ins); 
+            end
+            "c.swsp"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rs2(0);
+                ins.add_imm(1);
+                ins.add_rs1_2();
+                ins.current.inst_category = INST_CAT_STORE;
+                ins.add_mem_address();
+                c_swsp_cg.sample(ins); 
+            end
+            "c.li"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
                 ins.add_imm(1);
                 c_li_cg.sample(ins); 
             end
-            "lui"     : begin 
+            "c.lui"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
                 ins.add_imm(1);
                 c_lui_cg.sample(ins); 
             end
-            "srli"     : begin 
+            "c.srli"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_imm(2);
+                ins.add_rs1(0);
+                ins.add_imm(1);
                 c_srli_cg.sample(ins); 
             end
-            "srai"     : begin 
+            "c.srai"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_imm(2);
+                ins.add_rs1(0);
+                ins.add_imm(1);
                 c_srai_cg.sample(ins); 
             end
-            "andi"     : begin 
+            "c.andi"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_imm(2);
+                ins.add_rs1(0);
+                ins.add_imm(1);
                 c_andi_cg.sample(ins); 
             end
-            "sub"     : begin 
+            "c.sub"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_rs2(2);
+                ins.add_rs1(0);
+                ins.add_rs2(1);
                 c_sub_cg.sample(ins); 
             end
-            "xor"     : begin 
+            "c.xor"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_rs2(2);
+                ins.add_rs1(0);
+                ins.add_rs2(1);
                 c_xor_cg.sample(ins);
             end
-            "or"     : begin 
+            "c.or"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_rs2(2);
+                ins.add_rs1(0);
+                ins.add_rs2(1);
                 c_or_cg.sample(ins); 
             end
-            "and"     : begin 
+            "c.and"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_rs2(2);
+                ins.add_rs1(0);
+                ins.add_rs2(1);
                 c_and_cg.sample(ins); 
             end
-            "j"     : begin 
+            "c.j"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_imm_addr(0);
                 c_j_cg.sample(ins); 
             end
-            "beqz"     : begin 
+            "c.beqz"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rs1(0);
                 ins.add_imm_addr(1);
                 c_beqz_cg.sample(ins); 
             end
-            "bnez"     : begin 
+            "c.bnez"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rs1(0);
                 ins.add_imm_addr(1);
                 c_bnez_cg.sample(ins); 
             end
-            "slli"     : begin 
+            "c.slli"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
-                ins.add_imm(2);
+                ins.add_imm(1);
                 c_slli_cg.sample(ins);
             end
-            "jr"     : begin 
+            "c.jr"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rs1(0);
                 c_jr_cg.sample(ins); 
             end
-            "mv"     : begin 
+            "c.mv"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
                 ins.add_rs2(1);
                 c_mv_cg.sample(ins); 
             end
-            "jalr"     : begin 
+            "c.jalr"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd_1(); 
                 ins.add_rs1(0);
                 c_jalr_cg.sample(ins); 
             end
-            "add"     : begin 
+            "c.add"     : begin 
                 $display("recording compressed add");
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
-                ins.add_rs2(2);
+                ins.add_rs2(1);
                 c_add_cg.sample(ins); 
             end
-            "jal"     : begin 
+            "c.jal"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd_1(); 
                 ins.add_imm_addr(1);

--- a/templates/sample_RV32Zcb.txt
+++ b/templates/sample_RV32Zcb.txt
@@ -4,7 +4,7 @@ function void rv32zcb_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv32zcb_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "lbu"    : begin 
+            "c.lbu"    : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);                 
                 ins.add_imm(1);                
@@ -13,7 +13,7 @@ function void rv32zcb_sample(int hart, int issue);
                 ins.add_mem_address();         
                 c_lbu_cg.sample(ins); 
             end
-            "lh"     : begin 
+            "c.lh"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);                 
                 ins.add_imm(1);                
@@ -22,7 +22,7 @@ function void rv32zcb_sample(int hart, int issue);
                 ins.add_mem_address();         
                 c_lh_cg.sample(ins); 
             end
-            "lhu"    : begin 
+            "c.lhu"    : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);                 
                 ins.add_imm(1);                
@@ -31,7 +31,7 @@ function void rv32zcb_sample(int hart, int issue);
                 ins.add_mem_address();         
                 c_lhu_cg.sample(ins); 
             end
-            "sb"     : begin 
+            "c.sb"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rs2(0);                
                 ins.add_imm(1);                
@@ -40,7 +40,7 @@ function void rv32zcb_sample(int hart, int issue);
                 ins.add_mem_address();         
                 c_sb_cg.sample(ins); 
             end
-            "sh"     : begin 
+            "c.sh"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rs2(0);                
                 ins.add_imm(1);                
@@ -49,16 +49,16 @@ function void rv32zcb_sample(int hart, int issue);
                 ins.add_mem_address();         
                 c_sh_cg.sample(ins); 
             end
-            "not"    : begin 
+            "c.not"    : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0); 
-                ins.add_rs1(1);                                
+                ins.add_rs1(0);                                
                 c_not_cg.sample(ins); 
             end
-            "zext.b"    : begin 
+            "c.zext.b"    : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);  
-                ins.add_rs1(1);                               
+                ins.add_rs1(0);                               
                 c_zext_b_cg.sample(ins); 
             end
         endcase

--- a/templates/sample_RV32ZcbM.txt
+++ b/templates/sample_RV32ZcbM.txt
@@ -3,11 +3,11 @@ function void rv32zcbm_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv32zcbm_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "mul"     : begin
+            "c.mul"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[15:10] == 6'b100111) begin // Specific bits for "mul" 
                     ins = new(hart, issue, traceDataQ); 
                     ins.add_rd(0);                 
-                    ins.add_rs2(2);                
+                    ins.add_rs2(1);                
                     c_mul_cg.sample(ins);       
                 end
             end

--- a/templates/sample_RV32ZcbZbb.txt
+++ b/templates/sample_RV32ZcbZbb.txt
@@ -3,27 +3,27 @@ function void rv32zcbzbb_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv32zcbzbb_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "sext.b"     : begin
+            "c.sext.b"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[6:2] == 5'b11001) begin // Specific bits for "c.sext.b"
                     ins = new(hart, issue, traceDataQ);
                     ins.add_rd(0);
-                    ins.add_rs1(1);      
+                    ins.add_rs1(0);      
                     c_sext_b_cg.sample(ins); 
                 end
             end
-            "zext.h"     : begin
+            "c.zext.h"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[6:2] == 5'b11010) begin // Specific bits for "c.zext.h"
                     ins = new(hart, issue, traceDataQ);
                     ins.add_rd(0); 
-                    ins.add_rs1(1);     
+                    ins.add_rs1(0);     
                     c_zext_h_cg.sample(ins); 
                 end
             end
-            "sext.h"     : begin
+            "c.sext.h"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[6:2] == 5'b11011) begin // Specific bits for "c.sext.h"
                     ins = new(hart, issue, traceDataQ);
                     ins.add_rd(0); 
-                    ins.add_rs1(1);     
+                    ins.add_rs1(0);     
                     c_sext_h_cg.sample(ins); 
                 end
             end

--- a/templates/sample_RV32Zcd.txt
+++ b/templates/sample_RV32Zcd.txt
@@ -1,44 +1,40 @@
 function void rv32zcd_sample(int hart, int issue);
     ins_rv32zcd_t ins;
 
-    if (traceDataQ[hart][issue][0].insn[1:0] != 2'b11) begin // compressed instruction
-        $display("Examining compressed instruction rv32zcd_sample with inst_name = %s disass = %s", 
-                 traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
-
+    if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
+        $display("Examining compressed instruction rv32zcd_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "fld" :     begin
-                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00) begin // normal fld
-                    ins = new(hart, issue, traceDataQ);
-                    ins.add_fd(0);           
-                    ins.add_imm(1);          
-                    ins.add_rs1(2);          
-                    ins.add_mem_address();   
-                    c_fld_cg.sample(ins);
-                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b10) begin // fldsp  
-                    ins = new(hart, issue, traceDataQ);
-                    ins.add_fd(0);           
-                    ins.add_imm(1);          
-                    ins.add_rs1(2);          
-                    ins.add_mem_address();   
-                    c_fldsp_cg.sample(ins);                
-                end
+            "c.fld" :     begin
+                ins = new(hart, issue, traceDataQ);
+                ins.add_fd(0); 
+                ins.add_imm(1);
+                ins.add_rs1(2); 
+                ins.add_mem_address(); 
+                c_fld_cg.sample(ins); 
             end
-            "fsd" :     begin 
-                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00) begin // normal fsd
-                    ins = new(hart, issue, traceDataQ);
-                    ins.add_fs2(0);
-                    ins.add_imm(1); 
-                    ins.add_rs1(2); 
-                    ins.add_mem_address();
-                    c_fsd_cg.sample(ins); 
-                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b10) begin // fsdsp
-                    ins = new(hart, issue, traceDataQ);
-                    ins.add_fs2(0);
-                    ins.add_imm(1); 
-                    ins.add_rs1_2(); 
-                    ins.add_mem_address();
-                    c_fsdsp_cg.sample(ins);  
-                end
+            "c.fldsp" :     begin 
+                ins = new(hart, issue, traceDataQ);
+                ins.add_fd(0);           
+                ins.add_imm(1);          
+                ins.add_rs1_2();          
+                ins.add_mem_address();   
+                c_fldsp_cg.sample(ins);                
+            end
+            "c.fsd" :     begin 
+                ins = new(hart, issue, traceDataQ);
+                ins.add_fs2(0);
+                ins.add_imm(1); 
+                ins.add_rs1(2); 
+                ins.add_mem_address();
+                c_fsd_cg.sample(ins); 
+            end
+            "c.fsdsp" :     begin 
+                ins = new(hart, issue, traceDataQ);
+                ins.add_fs2(0);
+                ins.add_imm(1); 
+                ins.add_rs1_2(); 
+                ins.add_mem_address();
+                c_fsdsp_cg.sample(ins);  
             end
         endcase 
     end

--- a/templates/sample_RV32Zcf.txt
+++ b/templates/sample_RV32Zcf.txt
@@ -4,39 +4,37 @@ function void rv32zcf_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv32zcf_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "flw"     : begin 
-                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00) begin // normal flw
-                    ins = new(hart, issue, traceDataQ);
-                    ins.add_fd(0); 
-                    ins.add_imm(1);
-                    ins.add_rs1(2);
-                    ins.add_mem_address(); 
-                    c_flw_cg.sample(ins); 
-                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b10) begin // flwsp
-                    ins = new(hart, issue, traceDataQ);
-                    ins.add_fd(0); 
-                    ins.add_imm(1);
-                    ins.add_rs1_2(); 
-                    ins.add_mem_address(); 
-                    c_flwsp_cg.sample(ins);   
-                end 
+            "c.flw"     : begin 
+                ins = new(hart, issue, traceDataQ);
+                ins.add_fd(0); 
+                ins.add_imm(1);
+                ins.add_rs1(2);
+                ins.add_mem_address(); 
+                c_flw_cg.sample(ins); 
             end
-            "fsw"     : begin 
-                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00) begin // normal fsw
-                    ins = new(hart, issue, traceDataQ);
-                    ins.add_fs2(0);
-                    ins.add_imm(1); 
-                    ins.add_rs1(2); 
-                    ins.add_mem_address();
-                    c_fsw_cg.sample(ins); 
-                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b10) begin // fswsp
-                    ins = new(hart, issue, traceDataQ);
-                    ins.add_fs2(0);
-                    ins.add_imm(1); 
-                    ins.add_rs1_2(); 
-                    ins.add_mem_address();
-                    c_fswsp_cg.sample(ins);  
-                end 
+            "c.flwsp"     : begin     
+                ins = new(hart, issue, traceDataQ);
+                ins.add_fd(0); 
+                ins.add_imm(1);
+                ins.add_rs1_2(); 
+                ins.add_mem_address(); 
+                c_flwsp_cg.sample(ins);   
+            end
+            "c.fsw"     : begin 
+                ins = new(hart, issue, traceDataQ);
+                ins.add_fs2(0);
+                ins.add_imm(1); 
+                ins.add_rs1(2); 
+                ins.add_mem_address();
+                c_fsw_cg.sample(ins); 
+            end
+            "c.fswsp"     : begin     
+                ins = new(hart, issue, traceDataQ);
+                ins.add_fs2(0);
+                ins.add_imm(1); 
+                ins.add_rs1_2(); 
+                ins.add_mem_address();
+                c_fswsp_cg.sample(ins);  
             end
         endcase
     end

--- a/templates/sample_RV64Zca.txt
+++ b/templates/sample_RV64Zca.txt
@@ -4,247 +4,228 @@ function void rv64zca_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv64zca_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            // Distinguish among the three types of addi compressed instructions
-            "addi"     : begin 
-                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00 & traceDataQ[hart][issue][0].insn[15:13] == 3'b000) begin // addi4spn
+            // Distinguish among "c.add" and "c.nop"
+            "c.addi"     : begin 
+                if (traceDataQ[hart][issue][0].insn[15:0] == 1) begin   // c.nop
                     ins = new(hart, issue, traceDataQ); 
-                    ins.add_rd(0);
-                    ins.add_rs1(1);
-                    ins.add_imm(2);
-                    c_addi4spn_cg.sample(ins); 
-                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 & traceDataQ[hart][issue][0].insn[15:13] == 3'b011) begin // addi16sp
-                    ins = new(hart, issue, traceDataQ); 
-                    ins.add_rd(0);
-                    ins.add_imm(2);
-                    c_addi16sp_cg.sample(ins); 
-                end else if (traceDataQ[hart][issue][0].insn[15:1] == 0) begin // nop
-                    ins = new(hart, issue, traceDataQ); 
+                    ins.ins_str = "c.nop";  // Using correct inst name (c.nop instead of c.addi)
                     c_nop_cg.sample(ins); 
-                end else begin // ordinary addi
+                end else begin      // c.addi
                     ins = new(hart, issue, traceDataQ); 
                     ins.add_rd(0);
-                    ins.add_imm(2);
+                    ins.add_imm(1);
                     c_addi_cg.sample(ins); 
                 end
             end
-            "ld"     : begin 
-                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00 & traceDataQ[hart][issue][0].insn[15:13] == 3'b011) begin // normal ld
-                    ins = new(hart, issue, traceDataQ); 
-                    ins.add_rd(0);
-                    ins.add_imm(1);
-                    ins.add_rs1(2);
-                    ins.current.inst_category = INST_CAT_LOAD;
-                    ins.add_mem_address();
-                    c_ld_cg.sample(ins); 
-                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b10 & traceDataQ[hart][issue][0].insn[15:13] == 3'b011) begin // ldsp
-                    ins = new(hart, issue, traceDataQ); 
-                    ins.add_rd(0);
-                    ins.add_imm(1);
-                    ins.add_rs1_2();
-                    ins.current.inst_category = INST_CAT_LOAD;
-                    ins.add_mem_address();
-                    c_ldsp_cg.sample(ins); 
-                end 
-            end
-            "lw"     : begin 
-                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00 & traceDataQ[hart][issue][0].insn[15:13] == 3'b010) begin // normal lw
-                    ins = new(hart, issue, traceDataQ); 
-                    ins.add_rd(0);
-                    ins.add_imm(1);
-                    ins.add_rs1(2);
-                    ins.current.inst_category = INST_CAT_LOAD;
-                    ins.add_mem_address();
-                    c_lw_cg.sample(ins); 
-                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b10 & traceDataQ[hart][issue][0].insn[15:13] == 3'b010) begin // lwsp
-                    ins = new(hart, issue, traceDataQ); 
-                    ins.add_rd(0);
-                    ins.add_imm(1);
-                    ins.add_rs1_2();
-                    ins.current.inst_category = INST_CAT_LOAD;
-                    ins.add_mem_address();
-                    c_lwsp_cg.sample(ins); 
-                end 
-            end
-            "sw"     : begin 
-                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00 & traceDataQ[hart][issue][0].insn[15:13] == 3'b110) begin // normal sw
-                    ins = new(hart, issue, traceDataQ); 
-                    ins.add_rs2(0);
-                    ins.add_imm(1);
-                    ins.add_rs1(2);
-                    ins.current.inst_category = INST_CAT_STORE;
-                    ins.add_mem_address();
-                    c_sw_cg.sample(ins); 
-                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b10 & traceDataQ[hart][issue][0].insn[15:13] == 3'b110) begin // swsp
-                    ins = new(hart, issue, traceDataQ); 
-                    ins.add_rs2(0);
-                    ins.add_imm(1);
-                    ins.add_rs1_2();
-                    ins.current.inst_category = INST_CAT_STORE;
-                    ins.add_mem_address();
-                    c_swsp_cg.sample(ins); 
-                end 
-            end
-            "sd"     : begin 
-                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00 & traceDataQ[hart][issue][0].insn[15:13] == 3'b111) begin // normal sd
-                    ins = new(hart, issue, traceDataQ); 
-                    ins.add_rs2(0);
-                    ins.add_imm(1);
-                    ins.add_rs1(2);
-                    ins.current.inst_category = INST_CAT_STORE;
-                    ins.add_mem_address();
-                    c_sd_cg.sample(ins); 
-                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b10 & traceDataQ[hart][issue][0].insn[15:13] == 3'b111) begin // sdsp
-                    ins = new(hart, issue, traceDataQ); 
-                    ins.add_rs2(0);
-                    ins.add_imm(1);
-                    ins.add_rs1_2();
-                    ins.current.inst_category = INST_CAT_STORE;
-                    ins.add_mem_address();
-                    c_sdsp_cg.sample(ins); 
-                end 
-            end
-            "li"     : begin 
+            "c.addi4spn"     : begin   
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_rs1(1);
+                ins.add_imm(2);
+                c_addi4spn_cg.sample(ins); 
+            end 
+            "c.addi16sp"     : begin         
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
                 ins.add_imm(1);
-                c_li_cg.sample(ins); 
-            end
-            "lui"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rd(0);
-                ins.add_imm(1);
-                c_lui_cg.sample(ins); 
-            end
-            "srli"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_imm(2);
-                c_srli_cg.sample(ins); 
-            end
-            "srai"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_imm(2);
-                c_srai_cg.sample(ins); 
-            end
-            "andi"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_imm(2);
-                c_andi_cg.sample(ins); 
-            end
-            "sub"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_rs2(2);
-                c_sub_cg.sample(ins); 
-            end
-            "xor"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_rs2(2);
-                c_xor_cg.sample(ins); 
-            end
-            "or"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_rs2(2);
-                c_or_cg.sample(ins); 
-            end
-            "and"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_rs2(2);
-                c_and_cg.sample(ins); 
-            end
-            "j"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_imm_addr(0);
-                c_j_cg.sample(ins); 
-            end
-            "beqz"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rs1(0);
-                ins.add_imm_addr(1);
-                c_beqz_cg.sample(ins); 
-            end
-            "bnez"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rs1(0);
-                ins.add_imm_addr(1);
-                c_bnez_cg.sample(ins); 
-            end
-            "slli"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rd(0);
-                ins.add_imm(2);
-                c_slli_cg.sample(ins);
-            end
-            "ldsp"     : begin 
+                c_addi16sp_cg.sample(ins); 
+            end 
+            "c.ld"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
                 ins.add_imm(1);
                 ins.add_rs1(2);
                 ins.current.inst_category = INST_CAT_LOAD;
                 ins.add_mem_address();
+                c_ld_cg.sample(ins); 
+            end
+            "c.ldsp"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_imm(1);
+                ins.add_rs1_2();
+                ins.current.inst_category = INST_CAT_LOAD;
+                ins.add_mem_address();
                 c_ldsp_cg.sample(ins); 
             end
-            "jr"     : begin 
+            "c.lw"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_imm(1);
+                ins.add_rs1(2);
+                ins.current.inst_category = INST_CAT_LOAD;
+                ins.add_mem_address();
+                c_lw_cg.sample(ins);
+            end
+            "c.lwsp"     : begin  
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_imm(1);
+                ins.add_rs1_2();
+                ins.current.inst_category = INST_CAT_LOAD;
+                ins.add_mem_address();
+                c_lwsp_cg.sample(ins); 
+            end
+            "c.sw"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rs2(0);
+                ins.add_imm(1);
+                ins.add_rs1(2);
+                ins.current.inst_category = INST_CAT_STORE;
+                ins.add_mem_address();
+                c_sw_cg.sample(ins); 
+            end
+            "c.swsp"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rs2(0);
+                ins.add_imm(1);
+                ins.add_rs1_2();
+                ins.current.inst_category = INST_CAT_STORE;
+                ins.add_mem_address();
+                c_swsp_cg.sample(ins); 
+            end
+            "c.sd"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rs2(0);
+                ins.add_imm(1);
+                ins.add_rs1(2);
+                ins.current.inst_category = INST_CAT_STORE;
+                ins.add_mem_address();
+                c_sd_cg.sample(ins); 
+            end
+            "c.sdsp"     : begin    
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rs2(0);
+                ins.add_imm(1);
+                ins.add_rs1_2();
+                ins.current.inst_category = INST_CAT_STORE;
+                ins.add_mem_address();
+                c_sdsp_cg.sample(ins); 
+            end
+            "c.li"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_imm(1);
+                c_li_cg.sample(ins); 
+            end
+            "c.lui"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_imm(1);
+                c_lui_cg.sample(ins); 
+            end
+            "c.srli"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_rs1(0);
+                ins.add_imm(1);
+                c_srli_cg.sample(ins); 
+            end
+            "c.srai"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_rs1(0);
+                ins.add_imm(1);
+                c_srai_cg.sample(ins); 
+            end
+            "c.andi"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_rs1(0);
+                ins.add_imm(1);
+                c_andi_cg.sample(ins); 
+            end
+            "c.sub"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_rs1(0);
+                ins.add_rs2(1);
+                c_sub_cg.sample(ins); 
+            end
+            "c.xor"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_rs1(0);
+                ins.add_rs2(1);
+                c_xor_cg.sample(ins); 
+            end
+            "c.or"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_rs1(0);
+                ins.add_rs2(1);
+                c_or_cg.sample(ins); 
+            end
+            "c.and"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_rs1(0);
+                ins.add_rs2(1);
+                c_and_cg.sample(ins); 
+            end
+            "c.j"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_imm_addr(0);
+                c_j_cg.sample(ins); 
+            end
+            "c.beqz"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rs1(0);
+                ins.add_imm_addr(1);
+                c_beqz_cg.sample(ins); 
+            end
+            "c.bnez"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rs1(0);
+                ins.add_imm_addr(1);
+                c_bnez_cg.sample(ins); 
+            end
+            "c.slli"     : begin 
+                ins = new(hart, issue, traceDataQ); 
+                ins.add_rd(0);
+                ins.add_imm(1);
+                c_slli_cg.sample(ins);
+            end
+            "c.jr"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rs1(0);
                 c_jr_cg.sample(ins); 
             end
-            "mv"     : begin 
+            "c.mv"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
                 ins.add_rs2(1);
                 c_mv_cg.sample(ins); 
             end
-            "jalr"     : begin 
+            "c.jalr"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rs1(0);
                 c_jalr_cg.sample(ins); 
             end
-            "add"     : begin 
+            "c.add"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
-                ins.add_rs2(2);
+                ins.add_rs2(1);
                 c_add_cg.sample(ins); 
             end
-            "sdsp"     : begin 
-                ins = new(hart, issue, traceDataQ); 
-                ins.add_rs2(0);
-                ins.add_imm(1);  // adjust for 64-bit store operations
-                ins.add_rs1(2);
-                ins.current.inst_category = INST_CAT_STORE;
-                ins.add_mem_address();
-                c_sdsp_cg.sample(ins); 
-            end
-            "addiw"     : begin 
+            "c.addiw"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
-                ins.add_imm(2);
+                ins.add_imm(1);
                 c_addiw_cg.sample(ins); 
             end
-            "subw"     : begin 
+            "c.subw"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_rs2(2);
+                ins.add_rs1(0);
+                ins.add_rs2(1);
                 c_subw_cg.sample(ins); 
             end
-            "addw"     : begin 
+            "c.addw"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);
-                ins.add_rs1(1);
-                ins.add_rs2(2);
+                ins.add_rs1(0);
+                ins.add_rs2(1);
                 c_addw_cg.sample(ins); 
             end
         endcase

--- a/templates/sample_RV64Zcb.txt
+++ b/templates/sample_RV64Zcb.txt
@@ -3,7 +3,7 @@ function void rv64zcb_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv64zcb_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "lbu"    : begin 
+            "c.lbu"    : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);                 
                 ins.add_imm(1);                
@@ -12,7 +12,7 @@ function void rv64zcb_sample(int hart, int issue);
                 ins.add_mem_address();         
                 c_lbu_cg.sample(ins); 
             end
-            "lh"     : begin 
+            "c.lh"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);                 
                 ins.add_imm(1);                
@@ -21,7 +21,7 @@ function void rv64zcb_sample(int hart, int issue);
                 ins.add_mem_address();         
                 c_lh_cg.sample(ins); 
             end
-            "lhu"    : begin 
+            "c.lhu"    : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);                 
                 ins.add_imm(1);                
@@ -30,7 +30,7 @@ function void rv64zcb_sample(int hart, int issue);
                 ins.add_mem_address();         
                 c_lhu_cg.sample(ins); 
             end
-            "sb"     : begin 
+            "c.sb"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rs2(0);                
                 ins.add_imm(1);                
@@ -39,7 +39,7 @@ function void rv64zcb_sample(int hart, int issue);
                 ins.add_mem_address();         
                 c_sb_cg.sample(ins); 
             end
-            "sh"     : begin 
+            "c.sh"     : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rs2(0);                
                 ins.add_imm(1);                
@@ -48,16 +48,16 @@ function void rv64zcb_sample(int hart, int issue);
                 ins.add_mem_address();         
                 c_sh_cg.sample(ins); 
             end
-            "not"    : begin 
+            "c.not"    : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);                               
-                ins.add_rs1(1); 
+                ins.add_rs1(0); 
                 c_not_cg.sample(ins); 
             end
-            "zext.b"    : begin 
+            "c.zext.b"    : begin 
                 ins = new(hart, issue, traceDataQ); 
                 ins.add_rd(0);  
-                ins.add_rs1(1);                              
+                ins.add_rs1(0);                              
                 c_zext_b_cg.sample(ins); 
             end
         endcase

--- a/templates/sample_RV64ZcbM.txt
+++ b/templates/sample_RV64ZcbM.txt
@@ -3,11 +3,11 @@ function void rv64zcbm_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv64zcbm_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "mul"     : begin
+            "c.mul"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[15:10] == 6'b100111) begin // Specific bits for "mul" 
                     ins = new(hart, issue, traceDataQ); 
                     ins.add_rd(0);                  
-                    ins.add_rs2(2);                 
+                    ins.add_rs2(1);                 
                     c_mul_cg.sample(ins);           
                 end
             end

--- a/templates/sample_RV64ZcbZba.txt
+++ b/templates/sample_RV64ZcbZba.txt
@@ -3,10 +3,10 @@ function void rv64zcbzba_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv64zcbzba_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "zext.w"     : begin
+            "c.zext.w"     : begin
                 ins = new(hart, issue, traceDataQ);
                 ins.add_rd(0);       
-                ins.add_rs1(1);     
+                ins.add_rs1(0);     
                 c_zext_w_cg.sample(ins); 
             end
         endcase

--- a/templates/sample_RV64ZcbZbb.txt
+++ b/templates/sample_RV64ZcbZbb.txt
@@ -3,27 +3,27 @@ function void rv64zcbzbb_sample(int hart, int issue);
     if (traceDataQ[hart][issue][0].insn[1:0] != 3) begin // compressed instruction
         $display("Examining compressed instruction rv64zcbzbb_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "sext.b"     : begin
+            "c.sext.b"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[6:2] == 5'b11001) begin // Specific bits for "sext.b"
                     ins = new(hart, issue, traceDataQ);
                     ins.add_rd(0);      
-                    ins.add_rs1(1);     
+                    ins.add_rs1(0);     
                     c_sext_b_cg.sample(ins); 
                 end
             end
-            "zext.h"     : begin
+            "c.zext.h"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[6:2] == 5'b11010) begin // Specific bits for "zext.h"
                     ins = new(hart, issue, traceDataQ);
                     ins.add_rd(0);       
-                    ins.add_rs1(1);     
+                    ins.add_rs1(0);     
                     c_zext_h_cg.sample(ins); 
                 end
             end
-            "sext.h"     : begin
+            "c.sext.h"     : begin
                 if (traceDataQ[hart][issue][0].insn[1:0] == 2'b01 && traceDataQ[hart][issue][0].insn[6:2] == 5'b11011) begin // Specific bits for "sext.h"
                     ins = new(hart, issue, traceDataQ);
                     ins.add_rd(0);       
-                    ins.add_rs1(1);      
+                    ins.add_rs1(0);      
                     c_sext_h_cg.sample(ins); 
                 end
             end

--- a/templates/sample_RV64Zcd.txt
+++ b/templates/sample_RV64Zcd.txt
@@ -2,44 +2,39 @@ function void rv64zcd_sample(int hart, int issue);
     ins_rv64zcd_t ins;
     
     if (traceDataQ[hart][issue][0].insn[1:0] != 2'b11) begin // compressed instruction
-        $display("Examining compressed instruction rv64zcd_sample with inst_name = %s disass = %s", 
-                 traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
-        
+        $display("Examining compressed instruction rv64zcd_sample with inst_name = %s disass = %s", traceDataQ[hart][issue][0].inst_name, traceDataQ[hart][issue][0].disass);
         case (traceDataQ[hart][issue][0].inst_name)
-            "fld" :     begin
-                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00) begin // normal fld
-                    ins = new(hart, issue, traceDataQ);
-                    ins.add_fd(0);           
-                    ins.add_imm(1);          
-                    ins.add_rs1(2);          
-                    ins.add_mem_address();   
-                    c_fld_cg.sample(ins);
-                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b10) begin // fldsp  
-                    ins = new(hart, issue, traceDataQ);
-                    ins.add_fd(0);           
-                    ins.add_imm(1);          
-                    ins.add_rs1(2);          
-                    ins.add_mem_address();   
-                    c_fldsp_cg.sample(ins);                
-                end
+            "c.fld" :     begin
+                ins = new(hart, issue, traceDataQ);
+                ins.add_fd(0); 
+                ins.add_imm(1);
+                ins.add_rs1(2); 
+                ins.add_mem_address(); 
+                c_fld_cg.sample(ins); 
             end
-
-            "fsd" :     begin 
-                if (traceDataQ[hart][issue][0].insn[1:0] == 2'b00) begin // normal fsd
-                    ins = new(hart, issue, traceDataQ);
-                    ins.add_fs2(0);
-                    ins.add_imm(1); 
-                    ins.add_rs1(2); 
-                    ins.add_mem_address();
-                    c_fsd_cg.sample(ins); 
-                end else if (traceDataQ[hart][issue][0].insn[1:0] == 2'b10) begin // fsdsp
-                    ins = new(hart, issue, traceDataQ);
-                    ins.add_fs2(0);
-                    ins.add_imm(1); 
-                    ins.add_rs1_2(); 
-                    ins.add_mem_address();
-                    c_fsdsp_cg.sample(ins);  
-                end
+            "c.fldsp" :     begin 
+                ins = new(hart, issue, traceDataQ);
+                ins.add_fd(0);           
+                ins.add_imm(1);          
+                ins.add_rs1_2();          
+                ins.add_mem_address();   
+                c_fldsp_cg.sample(ins);                
+            end
+            "c.fsd" :     begin 
+                ins = new(hart, issue, traceDataQ);
+                ins.add_fs2(0);
+                ins.add_imm(1); 
+                ins.add_rs1(2); 
+                ins.add_mem_address();
+                c_fsd_cg.sample(ins); 
+            end
+            "c.fsdsp" :     begin 
+                ins = new(hart, issue, traceDataQ);
+                ins.add_fs2(0);
+                ins.add_imm(1); 
+                ins.add_rs1_2(); 
+                ins.add_mem_address();
+                c_fsdsp_cg.sample(ins);  
             end
         endcase 
     end


### PR DESCRIPTION
**PR#1077** in cvw enables **show_c_prefix**.

Removed code from covergroupgen.py and testgen.py which was specifically written for compressed instructions. 
With these changes, the coverage of all the compressed instructions dropped to zero. I made changes to the sample templates accordingly and brought the coverage back to 100%.

Previously some instructions such as c.ld and c.ldsp were both being shown as ld, and c.addi, c.addi16sp, c.addi4spn, c.nop were being represented as addi. With enabling 'c' prefix every instruction is now being represented by its own name, except for c.nop which is being displayed as c.addi but I added some special code in the sample template of Zca to handle c.nop.