### PR TITLE
Adding trap condition for Page and Access Faults

### DIFF
--- a/bin/coverreport.py
+++ b/bin/coverreport.py
@@ -70,7 +70,7 @@ for config in configs:
         os.system(cmd)
         
         # Use grep to get the lines that match the criteria
-        cmd = "grep -E '(Covergroup|TYPE|^ +([0-9]{1,2}|100)\\.[0-9]{2}%.*(ZERO|Covered|Uncovered)[[:space:]]*$)' " +reportdir+ "/report_" + config + ".txt > " + reportdir + "/temp_summary_" + config + ".txt"
+        cmd = "grep -E '(Covergroup|TYPE|^ +([0-9]{1,2}|100)\\.[0-9]{2}%.*(ZERO|Covered|Uncovered)[[:space:]]*$)' " + reportdir + "/report_" + config + ".txt | grep -v 'Covergroup instance' > " + reportdir + "/temp_summary_" + config + ".txt"
         os.system(cmd)
 
         # Process each line and replace the specified path pattern

--- a/fcov/rv32_priv/RV32VM_PMP_coverage.svh
+++ b/fcov/rv32_priv/RV32VM_PMP_coverage.svh
@@ -74,12 +74,12 @@ covergroup PMP_cg with function sample(ins_rv32vm_pmp_t ins);
         bins set = {1};
     }
 
-    Scause: coverpoint ins.current.csr[12'h142]{
+    Scause: coverpoint ins.current.csr[12'h142] iff (ins.trap == 1) {
         bins load_page_acc = {32'd5};
         bins ins_acc_fault  = {32'd1};
         bins store_amo_acc = {32'd7};
     }
-    Mcause: coverpoint  ins.current.csr[12'h342] {
+    Mcause: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
         bins load_page_acc = {32'd5};
         bins ins_acc_fault  = {32'd1};
         bins store_amo_acc = {32'd7};

--- a/fcov/rv32_priv/RV32VM_coverage.svh
+++ b/fcov/rv32_priv/RV32VM_coverage.svh
@@ -59,12 +59,12 @@ covergroup satp_cg with function sample(ins_rv32vm_t ins);
         wildcard bins csrrc = {32'b000110000000_?????_011_?????_1110011};
     }
 
-    access_u: cross priv_mode, ins, Mcause, tvm_mstatus { //sat.1
+    access_u: cross priv_mode, ins, Mcause, tvm_mstatus iff (ins.trap == 1) { //sat.1
         ignore_bins ig1 = binsof(priv_mode.S_mode);
         ignore_bins ig2 = binsof(priv_mode.M_mode);
         ignore_bins ig3 = binsof(Mcause.no_exception);
     }
-    access_m_s: cross priv_mode, ins, Mcause, tvm_mstatus { //sat.1
+    access_m_s: cross priv_mode, ins, Mcause, tvm_mstatus iff (ins.trap == 0) { //sat.1
         ignore_bins ig1 = binsof(priv_mode.U_mode);
         ignore_bins ig2 = binsof(Mcause.illegal_ins);
     }
@@ -107,7 +107,7 @@ covergroup mstatus_mprv_cg with function sample(ins_rv32vm_t ins);
         bins S_mode = {2'b01};
         bins M_mode = {2'b11};
     }
-    Scause: coverpoint ins.current.csr[12'h142]{
+    Scause: coverpoint ins.current.csr[12'h142] iff (ins.trap == 1) {
         bins illegal_ins = {32'd2};
     }
     ins: coverpoint ins.current.insn {
@@ -451,12 +451,12 @@ covergroup vm_permissions_cg with function sample(ins_rv32vm_t ins);
     write_acc: coverpoint ins.current.WriteAccess{
         bins set = {1};
     }
-    Scause: coverpoint  ins.current.csr[12'h142] {
+    Scause: coverpoint  ins.current.csr[12'h142] iff (ins.trap == 1) {
         bins load_page_fault = {32'd13};
         bins ins_page_fault  = {32'd12};
         bins store_amo_page_fault = {32'd15};
     }
-    Mcause: coverpoint  ins.current.csr[12'h342] {
+    Mcause: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
         bins load_page_fault = {32'd13};
         bins ins_page_fault  = {32'd12};
         bins store_amo_page_fault = {32'd15};

--- a/fcov/rv64_priv/RV64CBO_PMP_coverage.svh
+++ b/fcov/rv64_priv/RV64CBO_PMP_coverage.svh
@@ -56,10 +56,10 @@ covergroup exceptions_pmp_cg with function sample(ins_rv64cbo_pmp_t ins);
         bins set = {1};
     }
 
-    Scause: coverpoint ins.current.csr[12'h142]{
+    Scause: coverpoint ins.current.csr[12'h142] iff (ins.trap == 1){
         bins store_amo_acc = {64'd7};
     }
-    Mcause: coverpoint  ins.current.csr[12'h342] {
+    Mcause: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
         bins store_amo_acc = {64'd7};
     }
 

--- a/fcov/rv64_priv/RV64CBO_VM_coverage.svh
+++ b/fcov/rv64_priv/RV64CBO_VM_coverage.svh
@@ -178,10 +178,10 @@ covergroup exceptions_vm_cg with function sample(ins_rv64cbo_vm_t ins);
     write_acc: coverpoint ins.current.WriteAccess{
         bins set = {1};
     }
-    Scause: coverpoint  ins.current.csr[12'h142] {
+    Scause: coverpoint  ins.current.csr[12'h142] iff (ins.trap == 1) {
         bins store_amo_page_fault = {64'd15};
     }
-    Mcause: coverpoint  ins.current.csr[12'h342] {
+    Mcause: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
         bins store_amo_page_fault = {64'd15};
     }
     Nopagefault: coverpoint  ins.current.csr[12'h143]{

--- a/fcov/rv64_priv/RV64VM_PMP_coverage.svh
+++ b/fcov/rv64_priv/RV64VM_PMP_coverage.svh
@@ -83,12 +83,12 @@ covergroup PMP_cg with function sample(ins_rv64vm_pmp_t ins);
         bins set = {1};
     }
 
-    Scause: coverpoint ins.current.csr[12'h142]{
+    Scause: coverpoint ins.current.csr[12'h142] iff (ins.trap == 1) {
         bins load_page_acc = {64'd5};
         bins ins_acc_fault  = {64'd1};
         bins store_amo_acc = {64'd7};
     }
-    Mcause: coverpoint  ins.current.csr[12'h342] {
+    Mcause: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
         bins load_page_acc = {64'd5};
         bins ins_acc_fault  = {64'd1};
         bins store_amo_acc = {64'd7};

--- a/fcov/rv64_priv/RV64Zicbom_coverage.svh
+++ b/fcov/rv64_priv/RV64Zicbom_coverage.svh
@@ -39,7 +39,7 @@ covergroup cbo_inval_cg with function sample(ins_rv64zicbom_t ins);
     cbo: coverpoint ins.current.insn{
         wildcard bins inval = {32'b000000000000_?????_010_00000_0001111};
     }
-    Mcause: coverpoint  ins.current.csr[12'h342]{
+    Mcause: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
         bins illegal_ins = {64'd2};
     }
     illegal_ins_exception_m: cross priv_mode, menvcfg_cbie, cbo, Mcause{ //inv.1
@@ -91,7 +91,7 @@ covergroup cbo_clean_cg with function sample(ins_rv64zicbom_t ins);
     cbo: coverpoint ins.current.insn {
         wildcard bins clean = {32'b000000000001_?????_010_00000_0001111};
     }
-    Mcause: coverpoint  ins.current.csr[12'h342] {
+    Mcause: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
         bins illegal_ins = {64'd2};
     }
     illegal_ins_exception_m: cross priv_mode, menvcfg_cbcfe, cbo, Mcause{ //cl.1
@@ -129,7 +129,7 @@ covergroup cbo_flush_cg with function sample(ins_rv64zicbom_t ins);
     cbo: coverpoint ins.current.insn {
         wildcard bins flush = {32'b000000000010_?????_010_00000_0001111};
     }
-    Mcause: coverpoint  ins.current.csr[12'h342] {
+    Mcause: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
         bins illegal_ins = {64'd2};
     }
     illegal_ins_exception_m: cross priv_mode, menvcfg_cbcfe, cbo, Mcause{ //fl.1


### PR DESCRIPTION
Updating .svh coverage files for both 32 and 64 bits privilege coverage. Adding the trap condition on all page and access faults.