### PR TITLE
EndianS, EndianM, and EndianU Covergroups

### DIFF
--- a/bin/covergroupgen.py
+++ b/bin/covergroupgen.py
@@ -177,7 +177,8 @@ def writeCovergroups(testPlans, covergroupTemplates):
     keys = list(testPlans.keys())
     keys.sort()
     #List of priv cover groups
-    priv_defines = ["RV32VM", "RV32VM_PMP", "RV64VM", "RV64VM_PMP", "RV64Zicbom", "RV64CBO_PMP", "RV64CBO_VM", "ZicsrM", "ZicsrS", "ZicsrU", "ZicsrZicntrM", "ZicsrF", "ZicsrZicntrS", "ZicsrZicntrU"]
+    priv_defines = ["RV32VM", "RV32VM_PMP", "RV64VM", "RV64VM_PMP", "RV64Zicbom", "RV64CBO_PMP", "RV64CBO_VM", "ZicsrM", "ZicsrS", "ZicsrU", 
+                    "ZicntrM", "ZicsrF", "ZicntrS", "ZicntrU", "EndianU", "EndianS", "EndianM", "ExceptionM", "ExceptionS", "Exception"]
     file = "coverage/RISCV_coverage_base_init.svh"
     with open(os.path.join(covergroupDir,file), "w") as f: 
         for arch in keys:

--- a/bin/covergroupgen.py
+++ b/bin/covergroupgen.py
@@ -178,7 +178,7 @@ def writeCovergroups(testPlans, covergroupTemplates):
     keys.sort()
     #List of priv cover groups
     priv_defines = ["RV32VM", "RV32VM_PMP", "RV64VM", "RV64VM_PMP", "RV64Zicbom", "RV64CBO_PMP", "RV64CBO_VM", "ZicsrM", "ZicsrS", "ZicsrU", 
-                    "ZicntrM", "ZicsrF", "ZicntrS", "ZicntrU", "EndianU", "EndianS", "EndianM", "ExceptionM", "ExceptionS", "Exception"]
+                    "ZicntrM", "ZicsrF", "ZicntrS", "ZicntrU", "EndianU", "EndianS", "EndianM", "ExceptionM", "ExceptionS", "ExceptionU"]
     file = "coverage/RISCV_coverage_base_init.svh"
     with open(os.path.join(covergroupDir,file), "w") as f: 
         for arch in keys:

--- a/fcov/priv/EndianM_coverage.svh
+++ b/fcov/priv/EndianM_coverage.svh
@@ -1,0 +1,113 @@
+///////////////////////////////////////////
+//
+// RISC-V Architectural Functional Coverage Covergroups
+//
+// Copyright (C) 2024 Harvey Mudd College, 10x Engineers, UET Lahore, Habib University
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the “License”); you may not use this file 
+// except in compliance with the License, or, at your option, the Apache License version 2.0. You 
+// may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work distributed under the 
+// License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+// either express or implied. See the License for the specific language governing permissions 
+// and limitations under the License.
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+`define COVER_ENDIANM
+typedef RISCV_instruction #(ILEN, XLEN, FLEN, VLEN, NHART, RETIRE) ins_endianm_t;
+
+covergroup endianm_cg with function sample(ins_endianm_t ins);
+    option.per_instance = 0; 
+    // "Endianness tests in machine mode"
+
+    // building blocks for the main coverpoints
+        // ENDIANNESS COVERPOINTS: check writes and reads with various endianness
+    cp_sw: coverpoint ins.current.insn {
+        wildcard bins sw = {32'b????????????_?????_010_?????_0100011}; 
+    }
+    cp_sh: coverpoint ins.current.insn {
+        wildcard bins sh = {32'b????????????_?????_001_?????_0100011}; 
+    }
+    cp_sb: coverpoint ins.current.insn {
+        wildcard bins sb = {32'b????????????_?????_000_?????_0100011}; 
+    }
+    cp_lw: coverpoint ins.current.insn {
+        wildcard bins lw = {32'b????????????_?????_010_?????_0000011}; 
+    }
+    cp_lh: coverpoint ins.current.insn {
+        wildcard bins lh = {32'b????????????_?????_001_?????_0000011}; 
+    }
+    cp_lhu: coverpoint ins.current.insn {
+        wildcard bins lhu = {32'b????????????_?????_101_?????_0000011}; 
+    }
+    cp_lb: coverpoint ins.current.insn {
+        wildcard bins lb = {32'b????????????_?????_000_?????_0000011}; 
+    }
+    cp_lbu: coverpoint ins.current.insn {
+        wildcard bins lbu = {32'b????????????_?????_100_?????_0000011}; 
+    }
+    cp_byteoffset: coverpoint ins.current.imm[2:0] iff (ins.current.rs1_val[2:0] == 3'b000) {
+        // all byte offsets
+    }
+    cp_halfoffset: coverpoint ins.current.imm[2:1] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[0] == 1'b0)  {
+        // all halfword offsets
+    }    
+    cp_wordoffset: coverpoint ins.current.imm[2] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[1:0] == 2'b00)  {
+        // all word offsets
+    }    
+    `ifdef XLEN64
+        mstatus_mbe: coverpoint ins.current.csr[12'h300][37] { // mbe is mstatus[37] in RV64
+        }
+    `else
+        mstatus_mbe: coverpoint ins.current.csr[12'h310][5] { // mbe is mstatush[5] in RV32
+        }
+    `endif
+    priv_mode_m: coverpoint ins.current.mode { 
+       bins M_mode = {2'b11};
+    }   
+    // main coverpoints
+    cp_mstatus_mbe_endianness_sw: cross priv_mode_m, mstatus_mbe, cp_sw, cp_wordoffset;
+    cp_mstatus_mbe_endianness_sh: cross priv_mode_m, mstatus_mbe, cp_sh, cp_halfoffset;
+    cp_mstatus_mbe_endianness_sb: cross priv_mode_m, mstatus_mbe, cp_sb, cp_byteoffset;
+    cp_mstatus_mbe_endianness_lw: cross priv_mode_m, mstatus_mbe, cp_lw, cp_wordoffset;
+    cp_mstatus_mbe_endianness_lh: cross priv_mode_m, mstatus_mbe, cp_lh, cp_halfoffset;
+    cp_mstatus_mbe_endianness_lb: cross priv_mode_m, mstatus_mbe, cp_lb, cp_byteoffset;
+    cp_mstatus_mbe_endianness_lhu: cross priv_mode_m, mstatus_mbe, cp_lhu, cp_halfoffset;
+    cp_mstatus_mbe_endianness_lbu: cross priv_mode_m, mstatus_mbe, cp_lbu, cp_byteoffset;
+
+    `ifdef XLEN64
+        cp_sd: coverpoint ins.current.insn {
+            wildcard bins sd = {32'b????????????_?????_011_?????_0100011}; 
+        }
+        cp_ld: coverpoint ins.current.insn {
+            wildcard bins ld = {32'b????????????_?????_001_?????_0000011}; 
+        }
+        cp_lwu: coverpoint ins.current.insn {
+            wildcard bins lwu = {32'b????????????_?????_110_?????_0000011}; 
+        }
+        cp_doubleoffset: coverpoint ins.current.imm[2:0] iff (ins.current.rs1_val[2:0] == 3'b000)  {
+            bins zero = {3'b000};
+        }
+        cp_mstatus_mbe_endianness_sd: cross priv_mode_m, mstatus_mbe, cp_sd, cp_doubleoffset;
+        cp_mstatus_mbe_endianness_ld: cross priv_mode_m, mstatus_mbe, cp_ld, cp_doubleoffset;
+        cp_mstatus_mbe_endianness_lwu: cross priv_mode_m, mstatus_mbe, cp_lwu, cp_wordoffset;
+    `endif
+
+endgroup
+
+function void endianm_sample(int hart, int issue);
+    ins_endianm_t ins;
+
+    ins = new(hart, issue, traceDataQ); 
+    ins.add_rd(0);
+    ins.add_rs1(2);
+    ins.add_csr(1);
+    
+    endianm_cg.sample(ins);
+    
+endfunction

--- a/fcov/priv/EndianM_coverage_init.svh
+++ b/fcov/priv/EndianM_coverage_init.svh
@@ -1,0 +1,11 @@
+///////////////////////////////////////////
+//
+// RISC-V Architectural Functional Coverage Covergroups Initialization File
+// 
+// Copyright (C) 2024 Harvey Mudd College, 10x Engineers, UET Lahore, Habib University
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+    endianm_cg = new();         endianm_cg.set_inst_name("obj_endianm");

--- a/fcov/priv/EndianS_coverage.svh
+++ b/fcov/priv/EndianS_coverage.svh
@@ -85,12 +85,12 @@ covergroup endians_cg with function sample(ins_endians_t ins);
        bins S_mode = {2'b01};
     }
     priv_mode_u: coverpoint ins.current.mode { 
-       bins S_mode = {2'b00};
+       bins U_mode = {2'b00};
     }   
     mstatus_mprv: coverpoint ins.current.csr[12'h300][17] { // mprv is mstatus[17]
     }
     mstatus_mpp: coverpoint ins.current.csr[12'h300][12:11] { // mpp is mstatus[12:11]
-        bins U_Mode = {2'b00};
+        bins S_Mode = {2'b01};
         bins M_Mode = {2'b11};
     }
     // main coverpoints

--- a/fcov/priv/EndianS_coverage.svh
+++ b/fcov/priv/EndianS_coverage.svh
@@ -1,0 +1,157 @@
+///////////////////////////////////////////
+//
+// RISC-V Architectural Functional Coverage Covergroups
+//
+// Written: Corey Hickson chickson@hmc.edu 20 November 2024
+// 
+// Copyright (C) 2024 Harvey Mudd College, 10x Engineers, UET Lahore, Habib University
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the “License”); you may not use this file 
+// except in compliance with the License, or, at your option, the Apache License version 2.0. You 
+// may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work distributed under the 
+// License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+// either express or implied. See the License for the specific language governing permissions 
+// and limitations under the License.
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+`define COVER_ENDIANS
+typedef RISCV_instruction #(ILEN, XLEN, FLEN, VLEN, NHART, RETIRE) ins_endians_t;
+
+covergroup endians_cg with function sample(ins_endians_t ins);
+    option.per_instance = 0; 
+    // "Endianness tests in machine mode"
+
+    // building blocks for the main coverpoints
+        // ENDIANNESS COVERPOINTS: check writes and reads with various endianness
+    cp_sw: coverpoint ins.current.insn {
+        wildcard bins sw = {32'b????????????_?????_010_?????_0100011}; 
+    }
+    cp_sh: coverpoint ins.current.insn {
+        wildcard bins sh = {32'b????????????_?????_001_?????_0100011}; 
+    }
+    cp_sb: coverpoint ins.current.insn {
+        wildcard bins sb = {32'b????????????_?????_000_?????_0100011}; 
+    }
+    cp_lw: coverpoint ins.current.insn {
+        wildcard bins lw = {32'b????????????_?????_010_?????_0000011}; 
+    }
+    cp_lh: coverpoint ins.current.insn {
+        wildcard bins lh = {32'b????????????_?????_001_?????_0000011}; 
+    }
+    cp_lhu: coverpoint ins.current.insn {
+        wildcard bins lhu = {32'b????????????_?????_101_?????_0000011}; 
+    }
+    cp_lb: coverpoint ins.current.insn {
+        wildcard bins lb = {32'b????????????_?????_000_?????_0000011}; 
+    }
+    cp_lbu: coverpoint ins.current.insn {
+        wildcard bins lbu = {32'b????????????_?????_100_?????_0000011}; 
+    }
+    cp_byteoffset: coverpoint ins.current.imm[2:0] iff (ins.current.rs1_val[2:0] == 3'b000) {
+        // all byte offsets
+    }
+    cp_halfoffset: coverpoint ins.current.imm[2:1] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[0] == 1'b0)  {
+        // all halfword offsets
+    }    
+    cp_wordoffset: coverpoint ins.current.imm[2] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[1:0] == 2'b00)  {
+        // all word offsets
+    }    
+    `ifdef XLEN64
+        mstatus_mbe: coverpoint ins.current.csr[12'h300][37] { // mbe is mstatus[37] in RV64
+        }
+    `else
+        mstatus_mbe: coverpoint ins.current.csr[12'h310][5] { // mbe is mstatush[5] in RV32
+        }
+    `endif
+    `ifdef XLEN64
+        mstatus_sbe: coverpoint ins.current.csr[12'h300][36] { // sbe is mstatus[36] in RV64
+        }
+    `else
+        mstatus_sbe: coverpoint ins.current.csr[12'h310][4] { // sbe is mstatush[4] in RV32
+        }
+    `endif
+    sstatus_ube: coverpoint ins.current.csr[12'h100][6] { // ube is mstatus[6]
+    }
+    priv_mode_m: coverpoint ins.current.mode { 
+       bins M_mode = {2'b11};
+    }   
+    priv_mode_s: coverpoint ins.current.mode { 
+       bins S_mode = {2'b01};
+    }
+    priv_mode_u: coverpoint ins.current.mode { 
+       bins S_mode = {2'b00};
+    }   
+    mstatus_mprv: coverpoint ins.current.csr[12'h300][17] { // mprv is mstatus[17]
+    }
+    mstatus_mpp: coverpoint ins.current.csr[12'h300][12:11] { // mpp is mstatus[12:11]
+        bins U_Mode = {2'b00};
+        bins M_Mode = {2'b11};
+    }
+    // main coverpoints
+    cp_sstatus_sbe_endianness_sw:  cross priv_mode_s, mstatus_sbe, cp_sw,  cp_wordoffset;
+    cp_sstatus_sbe_endianness_sh:  cross priv_mode_s, mstatus_sbe, cp_sh,  cp_halfoffset;
+    cp_sstatus_sbe_endianness_sb:  cross priv_mode_s, mstatus_sbe, cp_sb,  cp_byteoffset;
+    cp_sstatus_sbe_endianness_lw:  cross priv_mode_s, mstatus_sbe, cp_lw,  cp_wordoffset;
+    cp_sstatus_sbe_endianness_lh:  cross priv_mode_s, mstatus_sbe, cp_lh,  cp_halfoffset;
+    cp_sstatus_sbe_endianness_lb:  cross priv_mode_s, mstatus_sbe, cp_lb,  cp_byteoffset;
+    cp_sstatus_sbe_endianness_lhu: cross priv_mode_s, mstatus_sbe, cp_lhu, cp_halfoffset;
+    cp_sstatus_sbe_endianness_lbu: cross priv_mode_s, mstatus_sbe, cp_lbu, cp_byteoffset;
+    cp_mstatus_mprv_sbe_endianness_sw:  cross priv_mode_m, mstatus_sbe, cp_sw,  cp_wordoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    cp_mstatus_mprv_sbe_endianness_sh:  cross priv_mode_m, mstatus_sbe, cp_sh,  cp_halfoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    cp_mstatus_mprv_sbe_endianness_sb:  cross priv_mode_m, mstatus_sbe, cp_sb,  cp_byteoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    cp_mstatus_mprv_sbe_endianness_lw:  cross priv_mode_m, mstatus_sbe, cp_lw,  cp_wordoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    cp_mstatus_mprv_sbe_endianness_lh:  cross priv_mode_m, mstatus_sbe, cp_lh,  cp_halfoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    cp_mstatus_mprv_sbe_endianness_lb:  cross priv_mode_m, mstatus_sbe, cp_lb,  cp_byteoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    cp_mstatus_mprv_sbe_endianness_lhu: cross priv_mode_m, mstatus_sbe, cp_lhu, cp_halfoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    cp_mstatus_mprv_sbe_endianness_lbu: cross priv_mode_m, mstatus_sbe, cp_lbu, cp_byteoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    cp_sstatus_ube_endianness_sw:  cross priv_mode_u, sstatus_ube, cp_sw,  cp_wordoffset;
+    cp_sstatus_ube_endianness_sh:  cross priv_mode_u, sstatus_ube, cp_sh,  cp_halfoffset;
+    cp_sstatus_ube_endianness_sb:  cross priv_mode_u, sstatus_ube, cp_sb,  cp_byteoffset;
+    cp_sstatus_ube_endianness_lw:  cross priv_mode_u, sstatus_ube, cp_lw,  cp_wordoffset;
+    cp_sstatus_ube_endianness_lh:  cross priv_mode_u, sstatus_ube, cp_lh,  cp_halfoffset;
+    cp_sstatus_ube_endianness_lb:  cross priv_mode_u, sstatus_ube, cp_lb,  cp_byteoffset;
+    cp_sstatus_ube_endianness_lhu: cross priv_mode_u, sstatus_ube, cp_lhu, cp_halfoffset;
+    cp_sstatus_ube_endianness_lbu: cross priv_mode_u, sstatus_ube, cp_lbu, cp_byteoffset;
+    `ifdef XLEN64
+        cp_sd: coverpoint ins.current.insn {
+            wildcard bins sd = {32'b????????????_?????_011_?????_0100011}; 
+        }
+        cp_ld: coverpoint ins.current.insn {
+            wildcard bins ld = {32'b????????????_?????_001_?????_0000011}; 
+        }
+        cp_lwu: coverpoint ins.current.insn {
+            wildcard bins lwu = {32'b????????????_?????_110_?????_0000011}; 
+        }
+        cp_doubleoffset: coverpoint ins.current.imm[2:0] iff (ins.current.rs1_val[2:0] == 3'b000)  {
+            bins zero = {3'b000};
+        }
+        cp_mstatus_mbe_endianness_sd:  cross priv_mode_s, mstatus_sbe, cp_sd,  cp_doubleoffset;
+        cp_mstatus_mbe_endianness_ld:  cross priv_mode_s, mstatus_sbe, cp_ld,  cp_doubleoffset;
+        cp_mstatus_mbe_endianness_lwu: cross priv_mode_s, mstatus_sbe, cp_lwu, cp_wordoffset;
+        cp_mstatus_mpr_ube_endianness_sd:  cross priv_mode_s, mstatus_sbe, cp_sd, cp_doubleoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+        cp_mstatus_mpr_ube_endianness_ld:  cross priv_mode_s, mstatus_sbe, cp_ld, cp_doubleoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+        cp_mstatus_mpr_ube_endianness_lwu: cross priv_mode_s, mstatus_sbe, cp_lwu,  cp_wordoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+        cp_sstatus_ube_endianness_sd:  cross priv_mode_u, sstatus_ube, cp_sd,  cp_doubleoffset;
+        cp_sstatus_ube_endianness_ld:  cross priv_mode_u, sstatus_ube, cp_ld,  cp_doubleoffset;
+        cp_sstatus_ube_endianness_lwu: cross priv_mode_u, sstatus_ube, cp_lwu, cp_wordoffset;
+    `endif
+
+endgroup
+
+function void endians_sample(int hart, int issue);
+    ins_endians_t ins;
+
+    ins = new(hart, issue, traceDataQ); 
+    ins.add_rd(0);
+    ins.add_rs1(2);
+    ins.add_csr(1);
+    
+    endians_cg.sample(ins);
+    
+endfunction

--- a/fcov/priv/EndianS_coverage_init.svh
+++ b/fcov/priv/EndianS_coverage_init.svh
@@ -1,0 +1,11 @@
+///////////////////////////////////////////
+//
+// RISC-V Architectural Functional Coverage Covergroups Initialization File
+// 
+// Copyright (C) 2024 Harvey Mudd College, 10x Engineers, UET Lahore, Habib University
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+    endians_cg = new();         endians_cg.set_inst_name("obj_endians");

--- a/fcov/priv/EndianU_coverage.svh
+++ b/fcov/priv/EndianU_coverage.svh
@@ -1,0 +1,133 @@
+///////////////////////////////////////////
+//
+// RISC-V Architectural Functional Coverage Covergroups
+//
+// Written: Corey Hickson chickson@hmc.edu 19 November 2024
+// 
+// Copyright (C) 2024 Harvey Mudd College, 10x Engineers, UET Lahore, Habib University
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the “License”); you may not use this file 
+// except in compliance with the License, or, at your option, the Apache License version 2.0. You 
+// may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work distributed under the 
+// License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+// either express or implied. See the License for the specific language governing permissions 
+// and limitations under the License.
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+`define COVER_ENDIANU
+typedef RISCV_instruction #(ILEN, XLEN, FLEN, VLEN, NHART, RETIRE) ins_endianu_t;
+
+covergroup endianu_cg with function sample(ins_endianu_t ins);
+    option.per_instance = 0; 
+    // "Endianness tests in user mode"
+
+    // building blocks for the main coverpoints
+    cp_sw: coverpoint ins.current.insn {
+        wildcard bins sw = {32'b????????????_?????_010_?????_0100011}; 
+    }
+    cp_sh: coverpoint ins.current.insn {
+        wildcard bins sh = {32'b????????????_?????_001_?????_0100011}; 
+    }
+    cp_sb: coverpoint ins.current.insn {
+        wildcard bins sb = {32'b????????????_?????_000_?????_0100011}; 
+    }
+    cp_lw: coverpoint ins.current.insn {
+        wildcard bins lw = {32'b????????????_?????_010_?????_0000011}; 
+    }
+    cp_lh: coverpoint ins.current.insn {
+        wildcard bins lh = {32'b????????????_?????_001_?????_0000011}; 
+    }
+    cp_lhu: coverpoint ins.current.insn {
+        wildcard bins lhu = {32'b????????????_?????_101_?????_0000011}; 
+    }
+    cp_lb: coverpoint ins.current.insn {
+        wildcard bins lb = {32'b????????????_?????_000_?????_0000011}; 
+    }
+    cp_lbu: coverpoint ins.current.insn {
+        wildcard bins lbu = {32'b????????????_?????_100_?????_0000011}; 
+    }
+    cp_byteoffset: coverpoint ins.current.imm[2:0] iff (ins.current.rs1_val[2:0] == 3'b000) {
+        // all byte offsets
+    }
+    cp_halfoffset: coverpoint ins.current.imm[2:1] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[0] == 1'b0)  {
+        // all halfword offsets
+    }    
+    cp_wordoffset: coverpoint ins.current.imm[2] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[1:0] == 2'b00)  {
+        // all word offsets
+    }    
+    priv_mode_u: coverpoint ins.current.mode {
+       bins U_mode = {2'b00};
+    }
+    mstatus_ube: coverpoint ins.current.csr[12'h300][6] { // ube is mstatus[6]
+    }
+    mstatus_mprv: coverpoint ins.current.csr[12'h300][17] { // mprv is mstatus[17]
+    }
+    mstatus_mpp: coverpoint ins.current.csr[12'h300][12:11] { // mprv is mstatus[12:11]
+        bins U_Mode = {2'b00};
+        bins M_Mode = {2'b11};
+    }
+    `ifdef XLEN64
+        mstatus_mbe: coverpoint ins.current.csr[12'h300][37] { // mbe is mstatus[37] in RV64
+    }
+    `else
+        mstatus_mbe: coverpoint ins.current.csr[12'h310][5] { // mbe is mstatush[5] in RV32
+    }
+    `endif
+    
+    // main coverpoints
+    cp_mstatus_ube_endianness_sw:  cross priv_mode_u, mstatus_ube, cp_sw,  cp_wordoffset;
+    cp_mstatus_ube_endianness_sh:  cross priv_mode_u, mstatus_ube, cp_sh,  cp_halfoffset;
+    cp_mstatus_ube_endianness_sb:  cross priv_mode_u, mstatus_ube, cp_sb,  cp_byteoffset;
+    cp_mstatus_ube_endianness_lw:  cross priv_mode_u, mstatus_ube, cp_lw,  cp_wordoffset;
+    cp_mstatus_ube_endianness_lh:  cross priv_mode_u, mstatus_ube, cp_lh,  cp_halfoffset;
+    cp_mstatus_ube_endianness_lb:  cross priv_mode_u, mstatus_ube, cp_lb,  cp_byteoffset;
+    cp_mstatus_ube_endianness_lhu: cross priv_mode_u, mstatus_ube, cp_lhu, cp_halfoffset;
+    cp_mstatus_ube_endianness_lbu: cross priv_mode_u, mstatus_ube, cp_lbu, cp_byteoffset;
+    cp_mstatus_mprv_ube_endianness_sw:  cross priv_mode_u, mstatus_ube, cp_sw,  cp_wordoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    cp_mstatus_mprv_ube_endianness_sh:  cross priv_mode_u, mstatus_ube, cp_sh,  cp_halfoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    cp_mstatus_mprv_ube_endianness_sb:  cross priv_mode_u, mstatus_ube, cp_sb,  cp_byteoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    cp_mstatus_mprv_ube_endianness_lw:  cross priv_mode_u, mstatus_ube, cp_lw,  cp_wordoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    cp_mstatus_mprv_ube_endianness_lh:  cross priv_mode_u, mstatus_ube, cp_lh,  cp_halfoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    cp_mstatus_mprv_ube_endianness_lb:  cross priv_mode_u, mstatus_ube, cp_lb,  cp_byteoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    cp_mstatus_mprv_ube_endianness_lhu: cross priv_mode_u, mstatus_ube, cp_lhu, cp_halfoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    cp_mstatus_mprv_ube_endianness_lbu: cross priv_mode_u, mstatus_ube, cp_lbu, cp_byteoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+
+    `ifdef XLEN64
+        cp_sd: coverpoint ins.current.insn {
+            wildcard bins sd = {32'b????????????_?????_011_?????_0100011}; 
+        }
+        cp_ld: coverpoint ins.current.insn {
+            wildcard bins ld = {32'b????????????_?????_001_?????_0000011}; 
+        }
+        cp_lwu: coverpoint ins.current.insn {
+            wildcard bins lwu = {32'b????????????_?????_110_?????_0000011}; 
+        }
+        cp_doubleoffset: coverpoint ins.current.imm[2:0] iff (ins.current.rs1_val[2:0] == 3'b000)  {
+            bins zero = {3'b000};
+        }
+        cp_mstatus_ube_endianness_sd:  cross priv_mode_u, mstatus_ube, cp_sd, cp_doubleoffset;
+        cp_mstatus_ube_endianness_ld:  cross priv_mode_u, mstatus_ube, cp_ld, cp_doubleoffset;
+        cp_mstatus_ube_endianness_lwu: cross priv_mode_u, mstatus_ube, cp_lwu, cp_wordoffset;
+        cp_mstatus_mpr_ube_endianness_sd:  cross priv_mode_u, mstatus_ube, cp_sd, cp_doubleoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+        cp_mstatus_mpr_ube_endianness_ld:  cross priv_mode_u, mstatus_ube, cp_ld, cp_doubleoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+        cp_mstatus_mpr_ube_endianness_lwu: cross priv_mode_u, mstatus_ube, cp_lwu, cp_wordoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
+    `endif
+endgroup
+
+function void endianu_sample(int hart, int issue);
+    ins_endianu_t ins;
+
+    ins = new(hart, issue, traceDataQ); 
+    ins.add_rd(0);
+    ins.add_rs1(2);
+    ins.add_csr(1);
+    
+    endianu_cg.sample(ins);
+    
+endfunction

--- a/fcov/priv/EndianU_coverage_init.svh
+++ b/fcov/priv/EndianU_coverage_init.svh
@@ -8,5 +8,4 @@
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-    ucsr_cg = new();         ucsr_cg.set_inst_name("obj_ucsr");
-    uprivinst_cg = new();    uprivinst_cg.set_inst_name("obj_uprivinst");
+    endianu_cg = new();         endianu_cg.set_inst_name("obj_endianu");

--- a/fcov/priv/ZicsrM_coverage.svh
+++ b/fcov/priv/ZicsrM_coverage.svh
@@ -275,73 +275,7 @@ covergroup mstatus_cg with function sample(ins_zicsrm_t ins);
     cp_mstatus_sd_write: cross priv_mode_m, csrrw_mstatus, cp_mstatus_sd, cp_mstatus_fs, cp_mstatus_vs, cp_mstatus_xs;
 
     
-    // ENDIANNESS COVERPOINTS: check writes and reads with various endianness
-    cp_sw: coverpoint ins.current.insn {
-        wildcard bins sw = {32'b????????????_?????_010_?????_0100011}; 
-    }
-    cp_sh: coverpoint ins.current.insn {
-        wildcard bins sh = {32'b????????????_?????_001_?????_0100011}; 
-    }
-    cp_sb: coverpoint ins.current.insn {
-        wildcard bins sb = {32'b????????????_?????_000_?????_0100011}; 
-    }
-    cp_lw: coverpoint ins.current.insn {
-        wildcard bins lw = {32'b????????????_?????_010_?????_0000011}; 
-    }
-    cp_lh: coverpoint ins.current.insn {
-        wildcard bins lh = {32'b????????????_?????_001_?????_0000011}; 
-    }
-    cp_lhu: coverpoint ins.current.insn {
-        wildcard bins lhu = {32'b????????????_?????_101_?????_0000011}; 
-    }
-    cp_lb: coverpoint ins.current.insn {
-        wildcard bins lb = {32'b????????????_?????_000_?????_0000011}; 
-    }
-    cp_lbu: coverpoint ins.current.insn {
-        wildcard bins lbu = {32'b????????????_?????_100_?????_0000011}; 
-    }
-    cp_byteoffset: coverpoint ins.current.imm[2:0] iff (ins.current.rs1_val[2:0] == 3'b000) {
-        // all byte offsets
-    }
-    cp_halfoffset: coverpoint ins.current.imm[2:1] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[0] == 1'b0)  {
-        // all halfword offsets
-    }    
-    cp_wordoffset: coverpoint ins.current.imm[2] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[1:0] == 2'b00)  {
-        // all word offsets
-    }    
-    `ifdef XLEN64
-        mstatus_mbe: coverpoint ins.current.csr[12'h300][37] { // mbe is mstatus[37] in RV64
-        }
-    `else
-        mstatus_mbe: coverpoint ins.current.csr[12'h310][5] { // mbe is mstatush[5] in RV32
-        }
-    `endif
-    cp_mstatus_mbe_endianness_sw: cross priv_mode_m, mstatus_mbe, cp_sw, cp_wordoffset;
-    cp_mstatus_mbe_endianness_sh: cross priv_mode_m, mstatus_mbe, cp_sh, cp_halfoffset;
-    cp_mstatus_mbe_endianness_sb: cross priv_mode_m, mstatus_mbe, cp_sb, cp_byteoffset;
-    cp_mstatus_mbe_endianness_lw: cross priv_mode_m, mstatus_mbe, cp_lw, cp_wordoffset;
-    cp_mstatus_mbe_endianness_lh: cross priv_mode_m, mstatus_mbe, cp_lh, cp_halfoffset;
-    cp_mstatus_mbe_endianness_lb: cross priv_mode_m, mstatus_mbe, cp_lb, cp_byteoffset;
-    cp_mstatus_mbe_endianness_lhu: cross priv_mode_m, mstatus_mbe, cp_lhu, cp_halfoffset;
-    cp_mstatus_mbe_endianness_lbu: cross priv_mode_m, mstatus_mbe, cp_lbu, cp_byteoffset;
 
-    `ifdef XLEN64
-        cp_sd: coverpoint ins.current.insn {
-            wildcard bins sd = {32'b????????????_?????_011_?????_0100011}; 
-        }
-        cp_ld: coverpoint ins.current.insn {
-            wildcard bins ld = {32'b????????????_?????_001_?????_0000011}; 
-        }
-        cp_lwu: coverpoint ins.current.insn {
-            wildcard bins lwu = {32'b????????????_?????_110_?????_0000011}; 
-        }
-        cp_doubleoffset: coverpoint ins.current.imm[2:0] iff (ins.current.rs1_val[2:0] == 3'b000)  {
-            bins zero = {3'b000};
-        }
-        cp_mstatus_mbe_endianness_sd: cross priv_mode_m, mstatus_mbe, cp_sd, cp_doubleoffset;
-        cp_mstatus_mbe_endianness_ld: cross priv_mode_m, mstatus_mbe, cp_ld, cp_doubleoffset;
-        cp_mstatus_mbe_endianness_lwu: cross priv_mode_m, mstatus_mbe, cp_lwu, cp_wordoffset;
-    `endif
 
  endgroup
 

--- a/fcov/priv/ZicsrU_coverage.svh
+++ b/fcov/priv/ZicsrU_coverage.svh
@@ -63,104 +63,6 @@ covergroup ucsr_cg with function sample(ins_zicsru_t ins);
     cp_csrcs:        cross csrop, csr, priv_mode_u, rs1_ones;
 endgroup
 
-covergroup mstatus_u_cg with function sample(ins_zicsru_t ins);
-    option.per_instance = 0; 
-    // "ZicsrU mstatus UBE"
-
-    // building blocks for the main coverpoints
-    cp_sw: coverpoint ins.current.insn {
-        wildcard bins sw = {32'b????????????_?????_010_?????_0100011}; 
-    }
-    cp_sh: coverpoint ins.current.insn {
-        wildcard bins sh = {32'b????????????_?????_001_?????_0100011}; 
-    }
-    cp_sb: coverpoint ins.current.insn {
-        wildcard bins sb = {32'b????????????_?????_000_?????_0100011}; 
-    }
-    cp_lw: coverpoint ins.current.insn {
-        wildcard bins lw = {32'b????????????_?????_010_?????_0000011}; 
-    }
-    cp_lh: coverpoint ins.current.insn {
-        wildcard bins lh = {32'b????????????_?????_001_?????_0000011}; 
-    }
-    cp_lhu: coverpoint ins.current.insn {
-        wildcard bins lhu = {32'b????????????_?????_101_?????_0000011}; 
-    }
-    cp_lb: coverpoint ins.current.insn {
-        wildcard bins lb = {32'b????????????_?????_000_?????_0000011}; 
-    }
-    cp_lbu: coverpoint ins.current.insn {
-        wildcard bins lbu = {32'b????????????_?????_100_?????_0000011}; 
-    }
-    cp_byteoffset: coverpoint ins.current.imm[2:0] iff (ins.current.rs1_val[2:0] == 3'b000) {
-        // all byte offsets
-    }
-    cp_halfoffset: coverpoint ins.current.imm[2:1] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[0] == 1'b0)  {
-        // all halfword offsets
-    }    
-    cp_wordoffset: coverpoint ins.current.imm[2] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[1:0] == 2'b00)  {
-        // all word offsets
-    }    
-    priv_mode_u: coverpoint ins.current.mode {
-       bins U_mode = {2'b00};
-    }
-    mstatus_ube: coverpoint ins.current.csr[12'h300][6] { // ube is mstatus[6]
-    }
-    mstatus_mprv: coverpoint ins.current.csr[12'h300][17] { // mprv is mstatus[17]
-    }
-    mstatus_mpp: coverpoint ins.current.csr[12'h300][12:11] { // mprv is mstatus[12:11]
-        bins U_Mode = {2'b00};
-        bins M_Mode = {2'b11};
-    }
-    `ifdef XLEN64
-        mstatus_mbe: coverpoint ins.current.csr[12'h300][37] { // mbe is mstatus[37] in RV64
-    }
-    `else
-        mstatus_mbe: coverpoint ins.current.csr[12'h310][5] { // mbe is mstatush[5] in RV32
-    }
-    `endif
-    
-    // main coverpoints
-    cp_mstatus_ube_endianness_sw:  cross priv_mode_u, mstatus_ube, cp_sw,  cp_wordoffset;
-    cp_mstatus_ube_endianness_sh:  cross priv_mode_u, mstatus_ube, cp_sh,  cp_halfoffset;
-    cp_mstatus_ube_endianness_sb:  cross priv_mode_u, mstatus_ube, cp_sb,  cp_byteoffset;
-    cp_mstatus_ube_endianness_lw:  cross priv_mode_u, mstatus_ube, cp_lw,  cp_wordoffset;
-    cp_mstatus_ube_endianness_lh:  cross priv_mode_u, mstatus_ube, cp_lh,  cp_halfoffset;
-    cp_mstatus_ube_endianness_lb:  cross priv_mode_u, mstatus_ube, cp_lb,  cp_byteoffset;
-    cp_mstatus_ube_endianness_lhu: cross priv_mode_u, mstatus_ube, cp_lhu, cp_halfoffset;
-    cp_mstatus_ube_endianness_lbu: cross priv_mode_u, mstatus_ube, cp_lbu, cp_byteoffset;
-    cp_mstatus_mprv_ube_endianness_sw:  cross priv_mode_u, mstatus_ube, cp_sw,  cp_wordoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
-    cp_mstatus_mprv_ube_endianness_sh:  cross priv_mode_u, mstatus_ube, cp_sh,  cp_halfoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
-    cp_mstatus_mprv_ube_endianness_sb:  cross priv_mode_u, mstatus_ube, cp_sb,  cp_byteoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
-    cp_mstatus_mprv_ube_endianness_lw:  cross priv_mode_u, mstatus_ube, cp_lw,  cp_wordoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
-    cp_mstatus_mprv_ube_endianness_lh:  cross priv_mode_u, mstatus_ube, cp_lh,  cp_halfoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
-    cp_mstatus_mprv_ube_endianness_lb:  cross priv_mode_u, mstatus_ube, cp_lb,  cp_byteoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
-    cp_mstatus_mprv_ube_endianness_lhu: cross priv_mode_u, mstatus_ube, cp_lhu, cp_halfoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
-    cp_mstatus_mprv_ube_endianness_lbu: cross priv_mode_u, mstatus_ube, cp_lbu, cp_byteoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
-
-    `ifdef XLEN64
-
-        cp_sd: coverpoint ins.current.insn {
-            wildcard bins sd = {32'b????????????_?????_011_?????_0100011}; 
-        }
-        cp_ld: coverpoint ins.current.insn {
-            wildcard bins ld = {32'b????????????_?????_001_?????_0000011}; 
-        }
-        cp_lwu: coverpoint ins.current.insn {
-            wildcard bins lwu = {32'b????????????_?????_110_?????_0000011}; 
-        }
-        cp_doubleoffset: coverpoint ins.current.imm[2:0] iff (ins.current.rs1_val[2:0] == 3'b000)  {
-            bins zero = {3'b000};
-        }
-        cp_mstatus_ube_endianness_sd:  cross priv_mode_u, mstatus_ube, cp_sd, cp_doubleoffset;
-        cp_mstatus_ube_endianness_ld:  cross priv_mode_u, mstatus_ube, cp_ld, cp_doubleoffset;
-        cp_mstatus_ube_endianness_lwu: cross priv_mode_u, mstatus_ube, cp_lwu, cp_wordoffset;
-        cp_mstatus_mpr_ube_endianness_sd:  cross priv_mode_u, mstatus_ube, cp_sd, cp_doubleoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
-        cp_mstatus_mpr_ube_endianness_ld:  cross priv_mode_u, mstatus_ube, cp_ld, cp_doubleoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
-        cp_mstatus_mpr_ube_endianness_lwu: cross priv_mode_u, mstatus_ube, cp_lwu, cp_wordoffset, mstatus_mprv, mstatus_mbe, mstatus_mpp;
-    `endif
-endgroup
-
 covergroup uprivinst_cg with function sample(ins_zicsru_t ins);
     option.per_instance = 0; 
     // "ZicsrU uprivinst"
@@ -197,7 +99,6 @@ function void zicsru_sample(int hart, int issue);
     ins.add_csr(1);
     
     ucsr_cg.sample(ins);
-    mstatus_u_cg.sample(ins);
     uprivinst_cg.sample(ins);
     
 endfunction


### PR DESCRIPTION
* Moved existing endian coverpoints into their own designated covergroups
* Created new covergroup for supervisor mode endian coverpoints 
* Added several privilege extensions/features to covergroupgen.py