### PR TITLE
Modified Makefile to run SV32 tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,22 @@ $(PRIVDIR)/Zicsr-CSR-Tests.h: bin/csrtests.py
 $(PRIVDIR)/ExceptionInstr-Tests.h $(PRIVDIR)/ExceptionInstrCompressed-Tests.h: bin/illegalinstrtests.py
 	bin/illegalinstrtests.py
 
+# This code is added especially for running VM SV32 tests
+# Replace --fcov with --lockstepverbose for debugging
+SV32DIR := ${WALLY}/tests/riscof/work/riscv-arch-test/rv32i_m/vm_sv32/src
+SV32OBJ = $(shell find $(SV32DIR)/*/dut -type f -name "*.$(OBJEXT)" | sort)
+# "make get_vm" outputs all the available SV32 tests in cvw-arch-verif/vm_tests.sh and "make vm" runs them
+get_vm:
+	@rm -f vm_tests.sh
+	@for elf in $(SV32OBJ); do \
+		echo "wsim rv32gc $$elf --fcov" >> vm_tests.sh; \
+	done
+vm:
+	rm -f ${WALLY}/sim/questa/fcov_ucdb/*
+	chmod +x vm_tests.sh
+	./vm_tests.sh
+	$(MAKE) merge
+
 # Some instructions get silently converted to 16-bit, this allows only Zc* instr to get converted to 16-bit 
 ZCA_FLAG = $(if $(findstring /Zca, $(dir $<)),_zca,)
 ZCB_FLAG = $(if $(findstring /Zcb, $(dir $<)),_zcb,)


### PR DESCRIPTION
After compilation of SV32 tests, they are placed in a very odd arrangement. Within the vm_sv32/src folder there are separate folders for each test, each having two folders (dut & ref) within which elf files are placed. It becomes hectic to run the tests directly. Therefore, I added this code in makefile to make it easier. 
**make get_vm** looks within all the dut folders within vm_sv32/src and grabs **elf** files. They are then placed in a file **vm_tests.sh** in the form of 
```
wsim rv32gc /home/mzain/cvw/tests/riscof/work/riscv-arch-test/rv32i_m/vm_sv32/src/mstatus_tvm_test.S/dut/my.elf --fcov
wsim rv32gc /home/mzain/cvw/tests/riscof/work/riscv-arch-test/rv32i_m/vm_sv32/src/pmp_check_on_pa_S_mode.S/dut/my.elf --fcov
wsim rv32gc /home/mzain/cvw/tests/riscof/work/riscv-arch-test/rv32i_m/vm_sv32/src/pmp_check_on_pa_U_mode.S/dut/my.elf --fcov
```
Here we can comment out the tests which we don't want to run.

Then running **make vm** executes this file and fetches functional coverage.
