### PR TITLE
Use path based on arch-verif instead of $WALLY

### DIFF
--- a/bin/combinetests.py
+++ b/bin/combinetests.py
@@ -10,6 +10,7 @@
 
 import os
 import re
+import sys
 
 def insertTemplate(out, template):
 	with open(templatedir+"/"+template) as f:
@@ -39,18 +40,13 @@ def combiineDir(testdir):
 				insertTests(out, file)
 		insertTemplate(out, "testgen_footer.S")
 
-WALLY = os.environ.get('WALLY')
-if not WALLY:
-	print("ERROR: WALLY environment variable not set")
-	exit(1)
-testdir = f"{WALLY}/addins/cvw-arch-verif/tests/rv32/I"
-testbasedir = f"{WALLY}/addins/cvw-arch-verif/tests"
+ARCH_VERIF = os.path.abspath(os.path.join(sys.argv[0], ".."))
 
-templatedir = 	f"{WALLY}/addins/cvw-arch-verif/templates"
+testbasedir = f"{ARCH_VERIF}/tests"
+templatedir = 	f"{ARCH_VERIF}/templates"
 
 # Find all the configurations in the fcov_ucdb directory
 for arch in ["rv32", "rv64"]:
-	#for testdir in [x[0] for x in os.walk(testbasedir+"/"+arch)]:
 	for ext in next(os.walk(testbasedir+"/"+arch))[1]:
 		testdir = f"{testbasedir}/{arch}/{ext}"
 		combiineDir(testdir)

--- a/bin/combinetests.py
+++ b/bin/combinetests.py
@@ -40,7 +40,7 @@ def combiineDir(testdir):
 				insertTests(out, file)
 		insertTemplate(out, "testgen_footer.S")
 
-ARCH_VERIF = os.path.abspath(os.path.join(sys.argv[0], ".."))
+ARCH_VERIF = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), ".."))
 
 testbasedir = f"{ARCH_VERIF}/tests"
 templatedir = 	f"{ARCH_VERIF}/templates"

--- a/bin/covergroupgen.py
+++ b/bin/covergroupgen.py
@@ -11,6 +11,7 @@
 import os
 import csv
 import re
+import sys
 
 ##################################
 # Functions
@@ -205,7 +206,7 @@ def writeCovergroups(testPlans, covergroupTemplates):
 ##################################
 
 if __name__ == '__main__':
-    ARCH_VERIF = os.path.abspath(os.path.join(sys.argv[0], ".."))
+    ARCH_VERIF = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), ".."))
     missingTemplates = list() # keep list of missing templates to only print once
     testPlans = readTestplans()
     covergroupTemplates = readCovergroupTemplates()

--- a/bin/covergroupgen.py
+++ b/bin/covergroupgen.py
@@ -17,13 +17,13 @@ import re
 ##################################
 
 # readTestplans iterates over all of the CSV testplan files in the testplans directory
-# It poupulates a dictionary of dictionaries with 
+# It poupulates a dictionary of dictionaries with
 # the top level key being the architecture (e.g. RV64I)
 # the second level key being the instruction mnemonic (e.g. add)
 # the value being a list of covergroups for that instruction
 
 def readTestplans():
-    coverplanDir = WALLY+'/addins/cvw-arch-verif/testplans'
+    coverplanDir = f'{ARCH_VERIF}/testplans'
     testplans = dict()
     for file in os.listdir(coverplanDir):
         if file.endswith(".csv"):
@@ -45,7 +45,7 @@ def readTestplans():
                         if (type(value) == str and value != ''):
                             if(key == "Type"):
                                 cps.append("sample_" + value)
-                            else: 
+                            else:
                                 if (value != "x"): # for special entries, append the entry name (e.g. cp_rd_corners becomes cp_rd_corners_lui)
                                     key = key + "_" + value
                                 cps.append(key)
@@ -57,7 +57,7 @@ def readTestplans():
 # readCovergroupTemplates reads the covergroup templates from the templates directory
 
 def readCovergroupTemplates():
-    templateDir = WALLY+'/addins/cvw-arch-verif/templates'
+    templateDir = f'{ARCH_VERIF}/templates'
     covergroupTemplates = dict()
     for file in os.listdir(templateDir):
         if file.endswith(".txt"):
@@ -94,49 +94,49 @@ def customizeTemplate(covergroupTemplates, name, arch, instr):
     # addi rd, rs1, 0, is renamed to the psuedoinstruction mv rd, rs1 causing the covergroup to miss it.
     # To ensure full coverage, we add 'mv' along with 'addi' in the covergroup.
     # addi/mv uses its ordinary rs1 field and neither use rs2, so the sample function arguments are unchanged
-    # if name.startswith('sample_') and instr == 'addi': 
-    #     template += template.replace(instr, 'mv', 1)    
-    # # pseudoinstructions with rd tied to x0 must use the special add_rd_0 function 
-    # if name.startswith('sample_') and instr == 'jal': 
+    # if name.startswith('sample_') and instr == 'addi':
+    #     template += template.replace(instr, 'mv', 1)
+    # # pseudoinstructions with rd tied to x0 must use the special add_rd_0 function
+    # if name.startswith('sample_') and instr == 'jal':
     #     template += template.replace(instr, 'j', 1).replace("add_rd", "add_rd_0", 1).replace("ins.add_imm_addr(1)","ins.add_imm_addr(0)",1)
-    # if name.startswith('sample_') and instr == 'jalr': 
+    # if name.startswith('sample_') and instr == 'jalr':
     #     template += template.replace(instr, 'jr', 1).replace("add_rd", "add_rd_0", 1).replace("ins.add_imm_addr(1)","ins.add_imm_addr(0)",1).replace("ins.add_rs1(2)", "ins.add_rs1(1)",1) # works on generated tests, but fails on wally-riscv-arch-test MMU test that has a jr t2 (with no immediate)
     # if name.startswith('sample_') and instr == 'slt':
     #     template += template.replace(instr, 'sltz',1).replace("add_rs2","add_rs2_0",1)
     # # pseudoinstruction branches with rs2 tied to x0 must use the special add_rs2_0 function.  also immediate field is in different position
-    # if name.startswith('sample_') and instr == 'beq': 
+    # if name.startswith('sample_') and instr == 'beq':
     #     template += template.replace(instr, 'beqz', 1).replace("add_rs2", "add_rs2_0", 1).replace("add_imm_addr(2)", "add_imm_addr(1)", 1)
-    # if name.startswith('sample_') and instr == 'bne':  
+    # if name.startswith('sample_') and instr == 'bne':
     #     template += template.replace(instr, 'bnez', 1).replace("add_rs2", "add_rs2_0", 1).replace("add_imm_addr(2)", "add_imm_addr(1)", 1)
-    # if name.startswith('sample_') and instr == 'bge':  
+    # if name.startswith('sample_') and instr == 'bge':
     #     template += template.replace(instr, 'bgez', 1).replace("add_rs2", "add_rs2_0", 1).replace("add_imm_addr(2)", "add_imm_addr(1)", 1)
-    # if name.startswith('sample_') and instr == 'blt':  
+    # if name.startswith('sample_') and instr == 'blt':
     #     template += template.replace(instr, 'bltz', 1).replace("add_rs2", "add_rs2_0", 1).replace("add_imm_addr(2)", "add_imm_addr(1)", 1)
     # # psueoinstructions branches such as blez with rs1 tied to x0 must use the special add_rs1_0 function and adjust position of immediate field
-    # if name.startswith('sample_') and instr == 'blt':  
+    # if name.startswith('sample_') and instr == 'blt':
     #     template += template.replace(instr, 'bgtz', 1).replace("add_rs1","add_rs1_0",1).replace("add_rs2(1)", "add_rs2(0)").replace("add_imm_addr(2)", "add_imm_addr(1)", 1)
-    # if name.startswith('sample_') and instr == 'bge':  
+    # if name.startswith('sample_') and instr == 'bge':
     #     template += template.replace(instr, 'blez', 1).replace("add_rs1","add_rs1_0",1).replace("add_rs2(1)", "add_rs2(0)").replace("add_imm_addr(2)", "add_imm_addr(1)", 1)
     # # psueoinstructions such as neg with rs1 tied to x0 must use the special add_rs1_0 function and take rs2 from argument 1 rather than 2
     # if name.startswith('sample_') and instr == 'sub':
     #     template += template.replace(instr, 'neg',1).replace("add_rs1","add_rs1_0",1).replace("add_rs2(2)", "add_rs2(1)")
     # if name.startswith('sample_') and instr == 'sltu':
     #     template += template.replace(instr, 'snez',1).replace("add_rs1","add_rs1_0",1).replace("add_rs2(2)", "add_rs2(1)")
-    # if name.startswith('sample_') and instr == 'sltiu': 
-    #     template += template.replace(instr, 'seqz', 1).replace("add_imm","add_imm_one",1)    
+    # if name.startswith('sample_') and instr == 'sltiu':
+    #     template += template.replace(instr, 'seqz', 1).replace("add_imm","add_imm_one",1)
     # instruction fmv.x.w interpreted by imperas as fmv.x.s (deprecaited names)
     # if name.startswith('sample_') and instr == 'fmv.x.w':
     #     template += template.replace(instr, 'fmv.x.s',1)
     # if name.startswith('sample_') and instr == 'fmv.w.x':
-    #     template += template.replace(instr, 'fmv.s.x',1)                
+    #     template += template.replace(instr, 'fmv.s.x',1)
     return template
 
-     
+
 # writeCovergroups iterates over the testplans and covergroup templates to generate the covergroups for
 # all instructions in each testplan
 
 def writeCovergroups(testPlans, covergroupTemplates):
-    covergroupDir = WALLY+'/addins/cvw-arch-verif/fcov'
+    covergroupDir = f'{ARCH_VERIF}/fcov'
     for arch, tp in testPlans.items():
         subdir = re.search("(RV..)", arch).group(1).lower()
         #subdir = os.path.join(subdir, "coverage")
@@ -177,11 +177,11 @@ def writeCovergroups(testPlans, covergroupTemplates):
     keys = list(testPlans.keys())
     keys.sort()
     #List of priv cover groups
-    priv_defines = ["RV32VM", "RV32VM_PMP", "RV64VM", "RV64VM_PMP", "RV64Zicbom", "RV64CBO_PMP", "RV64CBO_VM", "ZicsrM", "ZicsrS", "ZicsrU", 
+    priv_defines = ["RV32VM", "RV32VM_PMP", "RV64VM", "RV64VM_PMP", "RV64Zicbom", "RV64CBO_PMP", "RV64CBO_VM", "ZicsrM", "ZicsrS", "ZicsrU",
                     "ZicntrM", "ZicsrF", "ZicntrS", "ZicntrU", "EndianU", "EndianS", "EndianM", "ExceptionsM", "ExceptionsS", "ExceptionsU",
                     "ExceptionsZc", "ExceptionsF", "ExceptionsZalrsc", "ExceptionsZicboU", "ExceptionsZaamo", "ExceptionsZicboS"]
     file = "coverage/RISCV_coverage_base_init.svh"
-    with open(os.path.join(covergroupDir,file), "w") as f: 
+    with open(os.path.join(covergroupDir,file), "w") as f:
         for arch in keys:
             f.write(customizeTemplate(covergroupTemplates, "coverageinit", arch, ""))
         for define in priv_defines:
@@ -190,7 +190,7 @@ def writeCovergroups(testPlans, covergroupTemplates):
             f.write(f"       `include \"{define}_coverage_init.svh\"\n")
             f.write(f"   `endif\n \n")
     file = "coverage/RISCV_coverage_base_sample.svh"
-    with open(os.path.join(covergroupDir,file), "w") as f:        
+    with open(os.path.join(covergroupDir,file), "w") as f:
         for arch in keys:
             f.write(customizeTemplate(covergroupTemplates, "coveragesample", arch, ""))
         for define in priv_defines:
@@ -198,15 +198,15 @@ def writeCovergroups(testPlans, covergroupTemplates):
             f.write(f"       {define.lower()}_sample(hart, issue);\n")
             f.write(f"   `endif\n \n")
 
-    
+
 
 ##################################
 # Main Python Script
 ##################################
 
 if __name__ == '__main__':
-    WALLY = os.environ.get('WALLY')
-    missingTemplates = list() # keep li st of missing templates to only print once
+    ARCH_VERIF = os.path.abspath(os.path.join(sys.argv[0], ".."))
+    missingTemplates = list() # keep list of missing templates to only print once
     testPlans = readTestplans()
     covergroupTemplates = readCovergroupTemplates()
     writeCovergroups(testPlans, covergroupTemplates)

--- a/bin/coverreport.py
+++ b/bin/coverreport.py
@@ -15,22 +15,22 @@ def remove_duplicates_after_second_header(file_path):
     unique_lines_before_header = set()  # Set to store unique lines before the second header
     header_count = 0
     header_line = "Covergroup                                             Metric       Goal       Bins    Status"
-    
+
     # Read the file and process lines
     with open(file_path, 'r') as infile:
         lines = infile.readlines()
-    
+
     with open(file_path, 'w') as outfile:
         for line in lines:
             stripped_line = line.strip()  # Remove leading/trailing whitespace
-            
+
             # Check for the header line
             if stripped_line == header_line:
                 header_count += 1
                 # If it's the second header, skip writing it and continue
                 if header_count == 2:
                     continue
-            
+
             # If the second header has been found, filter out duplicates
             if header_count == 2:
                 if stripped_line not in unique_lines_before_header:
@@ -41,11 +41,12 @@ def remove_duplicates_after_second_header(file_path):
                 unique_lines_before_header.add(stripped_line)  # Add line to the set
 
 WALLY = os.environ.get('WALLY')
+ARCH_VERIF = os.path.abspath(os.path.join(sys.argv[0], ".."))
 if not WALLY:
 	print("ERROR: WALLY environment variable not set")
 	exit(1)
 ucdbdir = f"{WALLY}/sim/questa/fcov_ucdb"
-reportdir = f"{WALLY}/addins/cvw-arch-verif/work"
+reportdir = f"{ARCH_VERIF}/work"
 
 # Find all the configurations in the fcov_ucdb directory
 configs = {}
@@ -62,13 +63,13 @@ for config in configs:
         cmd = "vcover merge "+reportdir+"/merge_"+config+".ucdb "+ucdbdir+"/"+config+"*.ucdb"
         #print(cmd)
         os.system(cmd)
-        
+
         cmd = "vcover report -details "+reportdir+"/merge_"+config+".ucdb -output "+reportdir+"/report_"+config+".txt"
         os.system(cmd)
-        
+
         cmd = "vcover report -details "+reportdir+"/merge_"+config+".ucdb -below 100 -output "+reportdir+"/uncovered_"+config+".txt"
         os.system(cmd)
-        
+
         # Use grep to get the lines that match the criteria
         cmd = "grep -E '(Covergroup|TYPE|^ +([0-9]{1,2}|100)\\.[0-9]{2}%.*(ZERO|Covered|Uncovered)[[:space:]]*$)' " + reportdir + "/report_" + config + ".txt | grep -v 'Covergroup instance' > " + reportdir + "/temp_summary_" + config + ".txt"
         os.system(cmd)
@@ -84,7 +85,7 @@ for config in configs:
                     metric_match = re.search(r'\bMetric\b', line)
                     if metric_match:
                         metric_start_pos = metric_match.start()  # Store the starting position of "Metric"
-                    
+
                 if "TYPE" in line:
                     # Replace the pattern with spaces after '_cg'
                     line = re.sub(r'/RISCV_coverage_pkg/RISCV_coverage__1/', '', line)
@@ -105,7 +106,7 @@ for config in configs:
                                 percentage_start_pos = metric_start_pos + 1
                             else:
                                 percentage_start_pos = metric_start_pos
-                            
+
                             # Calculate necessary padding based on current position of the percentage
                             percentage_index = match.start()
 
@@ -115,7 +116,7 @@ for config in configs:
                                 line = line[:cg_index] + line[cg_index:].lstrip()
 
                 # Check if the current line starts with multiple spaces followed by a percentage
-                match = re.match(r'^ +\b((100|[0-9]{1,2})\.[0-9]{2})%', line) 
+                match = re.match(r'^ +\b((100|[0-9]{1,2})\.[0-9]{2})%', line)
                 if match and previous_line:
                     previous_line = previous_line.rstrip()
                     percentage_value = match.group(0)  # Get the matched percentage

--- a/bin/coverreport.py
+++ b/bin/coverreport.py
@@ -10,6 +10,7 @@
 
 import os
 import re
+import sys
 
 def remove_duplicates_after_second_header(file_path):
     unique_lines_before_header = set()  # Set to store unique lines before the second header
@@ -41,7 +42,7 @@ def remove_duplicates_after_second_header(file_path):
                 unique_lines_before_header.add(stripped_line)  # Add line to the set
 
 WALLY = os.environ.get('WALLY')
-ARCH_VERIF = os.path.abspath(os.path.join(sys.argv[0], ".."))
+ARCH_VERIF = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), ".."))
 if not WALLY:
 	print("ERROR: WALLY environment variable not set")
 	exit(1)

--- a/bin/csrtests.py
+++ b/bin/csrtests.py
@@ -9,7 +9,7 @@
 ##################################
 
 import random
-from random import randint 
+from random import randint
 from random import seed
 import os, sys
 from os import environ
@@ -56,14 +56,14 @@ def csrtests(pathname, US):
         reg3 = str(reg3)
         ih = hex(i)
         print("\n// Testing CSR "+ih)
-        print("\tcsrr x"+str(reg1)+", "+ ih + "\t// Read CSR")   
+        print("\tcsrr x"+str(reg1)+", "+ ih + "\t// Read CSR")
         if (i < 0x3A0 or i > 0x3EF or US): # skip writing PMP registers, which are touchy and tested separately
             print("\tli x"+reg2+", -1")
-            print("\tcsrrw x"+reg3+", "+ih+", x"+reg2+"\t// Write all 1s to CSR") 
+            print("\tcsrrw x"+reg3+", "+ih+", x"+reg2+"\t// Write all 1s to CSR")
             print("\tcsrrw x"+reg3+", "+ih+", x0\t// Write all 0s to CSR")
             print("\tcsrrs x"+reg3+", "+ih+", x"+reg2+"\t// Set all CSR bits")
             print("\tcsrrc x"+reg3+", "+ih+", x"+reg2+"\t// Clear all CSR bits")
-            print("\tcsrrw x"+reg3+", "+ih+", x"+reg1+"\t// Restore CSR")   
+            print("\tcsrrw x"+reg3+", "+ih+", x"+reg1+"\t// Restore CSR")
         else:
             print("\t// Don't try reading or writing PMP in machine mode because the weird patterns hang the DUT")
     outfile.close
@@ -74,24 +74,24 @@ seed(0) # make tests reproducible
 # generate repetitive assembly language tests
 
 # writable registers to test with walking 1s and 0s
-mregs = ["mstatus", "mcause", "misa", "medeleg", "mideleg", "mie", "mtvec", "mcounteren", "mscratch", "mepc", "mtval", "mip", "menvcfg", "mcycle", "mcountinhibit", "mstatush", "mcycleh", "minstreth", "mseccfg", "mseccfgh"] 
+mregs = ["mstatus", "mcause", "misa", "medeleg", "mideleg", "mie", "mtvec", "mcounteren", "mscratch", "mepc", "mtval", "mip", "menvcfg", "mcycle", "mcountinhibit", "mstatush", "mcycleh", "minstreth", "mseccfg", "mseccfgh"]
 sregs = ["sstatus", "scause", "sie", "stvec", "scounteren", "senvcfg", "sscratch", "sepc", "stval", "sip", "satp", "0x120"] # 0x120 is scountinhibit
 uregs = ["fflags", "frm", "fcsr"]
 
-WALLY = os.environ.get('WALLY')
+ARCH_VERIF = os.path.abspath(os.path.join(sys.argv[0], ".."))
 
-pathname = WALLY+"/addins/cvw-arch-verif/tests/priv/Zicsr-CSR-Tests.h"
+pathname = f"{ARCH_VERIF}/tests/priv/Zicsr-CSR-Tests.h"
 csrtests(pathname, False) # make tests for M mode
 
-pathname = WALLY+"/addins/cvw-arch-verif/tests/priv/Zicsr-CSR-USPMPWrite-Tests.h"
+pathname = f"{ARCH_VERIF}/tests/priv/Zicsr-CSR-USPMPWrite-Tests.h"
 csrtests(pathname, True) # additional tests to read/write PMP registers in U/S mode
 
-pathname = WALLY+"/addins/cvw-arch-verif/tests/priv/ZicsrM-Walk.h"
+pathname = f"{ARCH_VERIF}/tests/priv/ZicsrM-Walk.h"
 csrwalk(pathname, mregs + sregs + uregs);
 
-pathname = WALLY+"/addins/cvw-arch-verif/tests/priv/ZicsrS-Walk.h"
+pathname = f"{ARCH_VERIF}/tests/priv/ZicsrS-Walk.h"
 csrwalk(pathname, sregs + uregs);
 
-pathname = WALLY+"/addins/cvw-arch-verif/tests/priv/ZicsrU-Walk.h"
+pathname = f"{ARCH_VERIF}/tests/priv/ZicsrU-Walk.h"
 csrwalk(pathname, uregs);
 

--- a/bin/csrtests.py
+++ b/bin/csrtests.py
@@ -78,7 +78,7 @@ mregs = ["mstatus", "mcause", "misa", "medeleg", "mideleg", "mie", "mtvec", "mco
 sregs = ["sstatus", "scause", "sie", "stvec", "scounteren", "senvcfg", "sscratch", "sepc", "stval", "sip", "satp", "0x120"] # 0x120 is scountinhibit
 uregs = ["fflags", "frm", "fcsr"]
 
-ARCH_VERIF = os.path.abspath(os.path.join(sys.argv[0], ".."))
+ARCH_VERIF = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), ".."))
 
 pathname = f"{ARCH_VERIF}/tests/priv/Zicsr-CSR-Tests.h"
 csrtests(pathname, False) # make tests for M mode

--- a/bin/illegalinstrtests.py
+++ b/bin/illegalinstrtests.py
@@ -10,7 +10,7 @@
 ##################################
 
 import random
-from random import randint 
+from random import randint
 from random import seed
 import os, sys
 from os import environ
@@ -36,7 +36,7 @@ def gen(comment, template, len = 32, exclusion = []):
             elif (template[i] == '1'):
                 instr[i] = '1'
         instrstr = "".join(instr)
-        
+
         anymatch = 0
         for exclude in exclusion:
             match = 1
@@ -54,11 +54,11 @@ def gen(comment, template, len = 32, exclusion = []):
             print("     ."+keyword+" 0b"+instrstr)
         else:
             print("#     ."+keyword+" 0b"+instrstr+" // excluded by "+str(exclusion))
-   
+
 # setup
 seed(0) # make tests reproducible
-WALLY = os.environ.get('WALLY')
-pathname = WALLY+"/addins/cvw-arch-verif/tests/priv/ExceptionInstr-Tests.h"
+ARCH_VERIF = os.path.abspath(os.path.join(sys.argv[0], ".."))
+pathname = f"{ARCH_VERIF}/tests/priv/ExceptionInstr-Tests.h"
 outfile = open(pathname, 'w')
 sys.stdout = outfile
 gen("Illegal op2",  "RRRRRRRRRRRRRRRRRRRRRRRRR0001011")
@@ -77,7 +77,7 @@ gen("cp_fload",     "RRRRRRRRRRRRRRRRREEERRRRR0000111")
 gen("cp_fence_cbo", "RRRRRRRRRRRRRRRRREEERRRRR0001111")
 gen("cp_cbo_immediate", "EEEEEEEEEEEE00000010000000001111") # tie rs1 = 0 to avoid overwriting program on cbo.zero
 gen("cp_cbo_rd",        "00000000000RRRRRR010EEEEE0001111")
-gen("cp_Itype",         "EEEEEEEEEEEERRRRRE01RRRRR0010011")        
+gen("cp_Itype",         "EEEEEEEEEEEERRRRRE01RRRRR0010011")
 gen("cp_IWtype",        "RRRRRRRRRRRRRRRRREEERRRRR0011011")
 gen("cp_IWshift",       "EEEEEEERRRRRRRRRRE01RRRRR0011011")
 gen("cp_store",         "RRRRRRRRRRRR00000EEERRRRR0100011") # use rs1 = 0 for stores to avoid overwriting program
@@ -96,10 +96,10 @@ gen("cp_atomic_funct7", "EEEEERRRRRRR0000001ERRRRR0101111", 32, # use rs1 = 0 fo
                             "11100XXXXXXXXXXXX01XXXXXX0101111"  # exclude amomaxu to avoid stores to random locations
                         ])
 gen("cp_lrsc",          "00010RREEEEE0000001ERRRRR0101111")
-gen("cp_rtype",         "EEEEEEERRRRRRRRRREEERRRRR0110011") 
+gen("cp_rtype",         "EEEEEEERRRRRRRRRREEERRRRR0110011")
 gen("cp_rwtype",        "EEEEEEERRRRRRRRRREEERRRRR0111011")
 gen("cp_ftype",         "EEEEERRRRRRRRRRRREEERRRRR1010011")
-gen("cp_fsqrt",         "0101100EEEEERRRRRRRRRRRRR1010011") 
+gen("cp_fsqrt",         "0101100EEEEERRRRRRRRRRRRR1010011")
 gen("cp_fclass",        "1110000EEEEERRRRR001RRRRR1010011")
 gen("cp_fcvtif",        "1100000EEE00RRRRR000RRRRR1010011")
 gen("cp_fcvtif_fmt",    "11000EE000EERRRRR000RRRRR1010011")
@@ -120,7 +120,7 @@ gen("cp_jalr1",         "RRRRRRRRRRRRRRRRR010RRRRR1100111")
 gen("cp_jalr2",         "RRRRRRRRRRRRRRRRR100RRRRR1100111")
 gen("cp_jalr3",         "RRRRRRRRRRRRRRRRR110RRRRR1100111")
 gen("cp_privileged_f3", "00000000000100000EEE000001110011")
-gen("cp_privileged_000","EEEEEEEEEEEE00000000000001110011", 32, 
+gen("cp_privileged_000","EEEEEEEEEEEE00000000000001110011", 32,
     ["00X10000001000000000000001110011", # exclude mret and sret because there is no trap to return from
      "00010000010100000000000001110011"]) # exclude wfi because it may not wake up
 gen("cp_privileged_rd", "00000000000000000000EEEEE1110011")
@@ -128,11 +128,11 @@ gen("cp_privileged_rs2","000000000000EEEEE000000001110011")
 gen("cp_reserved_fma",  "RRRRRRRRRRRRRRRRREEERRRRR100EE11") # various reserved_rm*_fma*
 outfile.close
 
-pathname = WALLY+"/addins/cvw-arch-verif/tests/priv/ExceptionInstrCompressed-Tests.h"
+pathname = f"{ARCH_VERIF}/tests/priv/ExceptionInstrCompressed-Tests.h"
 outfile = open(pathname, 'w')
 sys.stdout = outfile
 gen("compressed00", "EEEEEEEEEEEEEE00", 16)
-gen("compressed01", "EEEEEEEEEEEEEE01", 16, 
+gen("compressed01", "EEEEEEEEEEEEEE01", 16,
     ["101XXXXXXXXXXX01", # skip c.j because it causes the test program to go to a random place
      "11XXXXXXXXXXXX01", # skip c.beqz and c.bnez because they cause program to go to a random place
      "001XXXXXXXXXXX01", # skip c.jr because it causes the test program to go to a random place

--- a/bin/illegalinstrtests.py
+++ b/bin/illegalinstrtests.py
@@ -57,7 +57,7 @@ def gen(comment, template, len = 32, exclusion = []):
 
 # setup
 seed(0) # make tests reproducible
-ARCH_VERIF = os.path.abspath(os.path.join(sys.argv[0], ".."))
+ARCH_VERIF = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), ".."))
 pathname = f"{ARCH_VERIF}/tests/priv/ExceptionInstr-Tests.h"
 outfile = open(pathname, 'w')
 sys.stdout = outfile

--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -17,6 +17,7 @@ from random import seed
 from random import getrandbits
 import os
 import re
+import sys
 
 ##################################
 # functions
@@ -1519,7 +1520,7 @@ def getcovergroups(coverdefdir, coverfiles):
 ##################################
 
 # change these to suite your tests
-ARCH_VERIF = os.path.abspath(os.path.join(sys.argv[0], ".."))
+ARCH_VERIF = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), ".."))
 rtype = ["add", "sub", "sll", "slt", "sltu", "xor", "srl", "sra", "or", "and",
         "addw", "subw", "sllw", "srlw", "sraw",
         "mul", "mulh", "mulhsu", "mulhu", "div", "divu", "rem", "remu",

--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -12,7 +12,7 @@
 # libraries
 ##################################
 from datetime import datetime
-from random import randint 
+from random import randint
 from random import seed
 from random import getrandbits
 import os
@@ -79,7 +79,7 @@ def SextImm6(imm):
 
 
 def ZextImm6(imm):
-  imm = imm % pow(2, 6) 
+  imm = imm % pow(2, 6)
   if test not in ["c.lw","c.sw","c.ld","c.sd","c.lwsp","c.ldsp","c.sdsp","c.swsp","c.flwsp","c.fswsp","c.fsdsp","c.fldsp"]:
     if imm == 0:
       imm = 8
@@ -163,7 +163,7 @@ def genFrmTests(testInstr):
     lines = lines + f"\n # set fcsr.frm to {csrMode} \n"
     lines = lines + f"fsrmi {csrMode}\n"
     lines = lines + f"{testInstr} # perform operation\n"
-  
+
   return lines
 
 def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen, rs3=None, rs3val=None, frm=False):
@@ -176,7 +176,7 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
   if (test in rtype):
     lines = lines + "li x" + str(rs1) + ", " + formatstr.format(rs1val) + " # initialize rs1\n"
     lines = lines + "li x" + str(rs2) + ", " + formatstr.format(rs2val) + " # initialize rs2\n"
-    lines = lines + test + " x" + str(rd) + ", x" + str(rs1) + ", x" + str(rs2) + " # perform operation\n" 
+    lines = lines + test + " x" + str(rd) + ", x" + str(rs1) + ", x" + str(rs2) + " # perform operation\n"
   elif (test in rbtype):
     lines = lines + "li x" + str(rs1) + ", " + formatstr.format(rs1val) + " # initialize rs1\n"
     lines = lines + test + " x" + str(rd) + ", x" + str(rs1) + " # perform operation\n"
@@ -210,7 +210,7 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
       lines = lines + "li x" + str(rs1) + ", " + formatstr.format(rs1val) + " # initialize rs1\n"
       lines = lines + f"{test} x{rd}, mscratch, {unsignedImm5(immval)} # perform operation\n"
   elif (test in citype):
-    if(test == "c.lui" and rd ==2): # rd ==2 is illegal operand 
+    if(test == "c.lui" and rd ==2): # rd ==2 is illegal operand
       rd = 9 # change to arbitrary other register
     elif (test == "c.addiw" and rd == 0):
       rd = 1
@@ -236,7 +236,7 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
         storeop = "c.sdsp"
         mul = 8
       while (rd == 0 and (test not in ["c.flwsp","c.fldsp"])):
-        rd = randint(1,31)     
+        rd = randint(1,31)
       while (rs2 == 2):
         rs2 = randint(1,31)
       lines = lines + "li x" + str(rs2) + ", " + formatstr.format(rs2val)  + " # initialize rs2\n"
@@ -262,7 +262,7 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
     else:
       imm = shiftImm(int(ZextImm6(immval)),xlen)
     lines = lines + "li x" + str(rd) + ", " + formatstr.format(rs2val)+"\n"
-    lines = lines + test + " x" + str(rd) + ", " + imm + " # perform operation\n" 
+    lines = lines + test + " x" + str(rd) + ", " + imm + " # perform operation\n"
   elif (test in crtype):
     if (test in ["c.add", "c.mv"]):
       if (rs2 == 0):
@@ -330,7 +330,7 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
   elif (test in cltype):
     rd = legalizecompr(rd)
     rs1 = legalizecompr(rs1)
-    rs2 = legalizecompr(rs2) 
+    rs2 = legalizecompr(rs2)
     while (rs1 == rs2):
       rs2 = randint(8,15)
     if test in ["c.lw","c.ld"]:
@@ -353,7 +353,7 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
         lines = lines + "addi x"     + str(rs1) + ", x" + str(rs1) + ", -" + str(int(unsignedImm5(immval))*mul) + " # sub immediate from rs1 to counter offset\n"
         lines = lines + "li x" + str(rs2) + ", " + formatstr.format(rs2val) + " # load immediate value into integer register\n"
         lines = lines + "sw x" + str(rs2) + ", " + str(int(unsignedImm5(immval))*mul) + "(x" + str(rs1) + ") # store value to memory\n"
-        lines = lines +  test + " f" + str(rd)  + ", " + str(int(unsignedImm5(immval))*mul) + "(x" + str(rs1) + ") # perform operation\n" 
+        lines = lines +  test + " f" + str(rd)  + ", " + str(int(unsignedImm5(immval))*mul) + "(x" + str(rs1) + ") # perform operation\n"
       elif (test == "c.fld"):
         storeop =  "sw" if (min (xlen, flen) == 32) else "sd"
         mul = 8
@@ -363,7 +363,7 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
           temp1 = randint(8,15)
         while (temp2 in [rs1, rs2, temp1]):
           temp2 = randint(8,15)
-        lines = lines + "addi x" + str(rs1) + ", x" + str(rs1) + ", " +  str(int(unsignedImm5(immval))*mul) + "\n"  
+        lines = lines + "addi x" + str(rs1) + ", x" + str(rs1) + ", " +  str(int(unsignedImm5(immval))*mul) + "\n"
         if (flen > xlen): # flen = 6
           rs2val = (rs2val << 32) | (rs1val)
           lines = lines + f"li x{temp1}, 0x{formatstrFP.format(rs2val)[2:10]} # load x{temp1} with 32 MSBs of {formatstrFP.format(rs2val)}\n"
@@ -372,7 +372,7 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
           lines = lines + f"addi x{rs1}, x{rs1}, 4 # move address up by 4\n"
           lines = lines + f"{storeop} x{temp2}, {str(int(unsignedImm5(immval))*mul)}(x{rs1}) # store x{temp2} (0x{formatstrFP.format(rs2val)[10:18]}) after 4 bytes in memory\n"
           lines = lines + f"addi x{rs1}, x{rs1}, -4 # move back to scratch\n"
-          lines = lines + f"{test} f{rd}, {str(int(unsignedImm5(immval))*mul)}(x{rs1}) # perform operation\n" 
+          lines = lines + f"{test} f{rd}, {str(int(unsignedImm5(immval))*mul)}(x{rs1}) # perform operation\n"
         else:
           lines = lines + f"li x{temp1}, {formatstrFP.format(rs2val)} # load x{temp1} with value {formatstrFP.format(rs2val)}\n"
           lines = lines + f"{storeop} x{temp1}, {str(int(unsignedImm5(immval))*mul)}(x{rs1}) # store {formatstrFP.format(rs2val)} in memory\n"
@@ -381,7 +381,7 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
   elif (test in clhtype or test in clbtype):
     rd = legalizecompr(rd)
     rs1 = legalizecompr(rs1)
-    rs2 = legalizecompr(rs2) 
+    rs2 = legalizecompr(rs2)
     while (rs1 == rs2):
       rs2 = randint(8,15)
     if (test in clhtype):
@@ -421,7 +421,7 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
         lines = lines + "s" + size + " x0, 0(x" + str(rs1) + ")" + " # clearing the random value store at scratch\n"
     lines = lines + "addi x" + str(rs1) + ", x" + str(rs1) + ", -" + str(int(unsignedImm5(immval))*mul) + " # sub immediate from rs1 to counter offset\n"
     lines = lines + test + (" f" if test in ["c.fsw","c.fsd"] else " x") + str(rs2) + ", " + str(int(unsignedImm5(immval))*mul) + "(x" + str(rs1) + ") # perform operation \n"
-    
+
   elif (test in cutype):
     rd = legalizecompr(rd)
     rs1 = legalizecompr(rs1)
@@ -454,7 +454,7 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
       lines = lines + "la sp" + ", scratch" + " # base address \n"
       lines = lines + test + " f" + str(rs2) +", " + str(int(ZextImm6(immval))*mul) + "(sp)" + "# perform operation\n"
     else:
-      lines = lines + "li x" + str(rs2) + ", " + formatstr.format(rs2val)  + " # initialize rs2\n" 
+      lines = lines + "li x" + str(rs2) + ", " + formatstr.format(rs2val)  + " # initialize rs2\n"
       lines = lines + "la sp" + ", scratch" + " # base address \n"
       lines = lines + test + " x" + str(rs2) +", " + str(int(ZextImm6(immval))*mul) + "(sp)" + "# perform operation\n"
   elif (test in csbtype):
@@ -535,15 +535,15 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
     else:
       lines = lines + f"li x{tempreg1}, {formatstrFP.format(rs2val)} # load x3 with value {formatstrFP.format(rs2val)}\n"
       lines = lines + f"{storeop} x{tempreg1}, {signedImm12(immval, immOffset=True)}(x{rs1}) # store {formatstrFP.format(rs2val)} in memory\n"
-      lines = lines + f"{test} f{rd}, {signedImm12(immval, immOffset=True)}(x{rs1}) # perform operation\n" 
+      lines = lines + f"{test} f{rd}, {signedImm12(immval, immOffset=True)}(x{rs1}) # perform operation\n"
   elif (test in fstype):#["fsw"]
-    while (rs1 == 0): 
-      rs1 = randint(1, 31) 
+    while (rs1 == 0):
+      rs1 = randint(1, 31)
     lines = lines + f"la x2, scratch # base address\n"
     lines = lines + loadFloatReg(rs2, rs2val, xlen, flen)
     lines = lines + f"la x{rs1}, scratch # base address\n"
     lines = lines + f"addi x{rs1}, x{rs1}, {signedImm12(-immval, immOffset=True)} # sub immediate from rs1 to counter offset\n"
-    lines = lines + test + " f" + str(rs2)  + ", " + signedImm12(immval, immOffset=True) + "(x" + str(rs1) + ") # perform operation\n" 
+    lines = lines + test + " f" + str(rs2)  + ", " + signedImm12(immval, immOffset=True) + "(x" + str(rs1) + ") # perform operation\n"
   elif (test in F2Xtype):#["fcvt.w.s", "fcvt.wu.s", "fmv.x.w"]
     while (rs2 == rs1):
       rs2 = randint(1, 31)
@@ -584,9 +584,9 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
   f.write(lines)
 
 def writeSingleInstructionSequence(desc, testlist, regconfiglist, rdlist, rs1list, rs2list, rs3list, immvalslist, commentlist, xlen):
-  
+
     #TODO Hamza: add input prechecks here later
-  
+
   registerArray = [rdlist, rs1list, rs2list, rs3list]
   global hazardLabel
 
@@ -603,7 +603,7 @@ def writeSingleInstructionSequence(desc, testlist, regconfiglist, rdlist, rs1lis
 
     elif insMap[instype].get('loadstore') == 'store':
       lines += (test + " " + regconfig[2] + str(registerArray[2][testindex]) +
-        ", " + signedImm12(immvalslist[testindex]) + 
+        ", " + signedImm12(immvalslist[testindex]) +
         "(" + regconfig[1] + str(registerArray[1][testindex]) + ")" + " # " + commentlist[testindex] + "\n")
 
     else:
@@ -633,17 +633,17 @@ def writeSingleInstructionSequence(desc, testlist, regconfiglist, rdlist, rs1lis
       if test == 'fcvtmod.w.d' :
         lines += ", rtz"
       lines += " # " + commentlist[testindex] + "\n"
-  
+
   return lines
 
 def writeHazardVector(desc, rs1a, rs2a, rda, rs1b, rs2b, rdb, testb, immvala, immvalb, regtotest, rs3a=None, rs3b=None, haz_type='waw', xlen=32):
   # consecutive instructions to trigger hazards
-  
+
   instype = findInstype('instructions', testb, insMap)
   regconfig = insMap[instype].get('regconfig','xxx_')
   implicitxreg = insMap[instype].get('implicitxreg', '____')
   global hazardLabel
-  
+
   testa = 'add'
 
   lines = "\n# Testcase " + str(desc) + "\n"
@@ -671,7 +671,7 @@ def writeHazardVector(desc, rs1a, rs2a, rda, rs1b, rs2b, rdb, testb, immvala, im
     if haz_type != "raw":
       lines += 'la x' + str(rs1b) + ', arbitraryLabel' + str(hazardLabel) + '\n'
       immvalb = 0
-    lines += writeSingleInstructionSequence(desc, 
+    lines += writeSingleInstructionSequence(desc,
                                 [testa],
                                 [regconfig2],
                                 [rda], [rs1a],
@@ -682,7 +682,7 @@ def writeHazardVector(desc, rs1a, rs2a, rda, rs1b, rs2b, rdb, testb, immvala, im
     if haz_type == "raw":
       lines += 'la x' + str(rs1b) + ', arbitraryLabel' + str(hazardLabel) + '\n'
       immvalb = 0
-    lines += writeSingleInstructionSequence(desc, 
+    lines += writeSingleInstructionSequence(desc,
                                 [testb],
                                 [regconfig],
                                 [rdb], [rs1b],
@@ -693,7 +693,7 @@ def writeHazardVector(desc, rs1a, rs2a, rda, rs1b, rs2b, rdb, testb, immvala, im
     lines += "arbitraryLabel" + str(hazardLabel) + ":\nnop\n"
     hazardLabel += 1
 
-  else: 
+  else:
 
     if test in fstype + fltype + stype + loaditype:
       lines += "la " + regconfig[1] + str(rs1b) + ", scratch\n"
@@ -702,7 +702,7 @@ def writeHazardVector(desc, rs1a, rs2a, rda, rs1b, rs2b, rdb, testb, immvala, im
         rs1a = rda
         rs2a = 0
 
-    lines += writeSingleInstructionSequence(desc, 
+    lines += writeSingleInstructionSequence(desc,
                     [testa, testb],
                     [regconfig2, regconfig],
                     [rda, rdb], [rs1a, rs1b],
@@ -749,15 +749,15 @@ def make_unique_hazard(test, regsA, haz_type='nohaz', regchoice=1):
         if compression == 2:
           regsB = legalizecompr(regsB)
       regsB[0] = regsA[0]
-    
+
     case "war":
       while (set(regsA) & set(regsB)):
         [rs1b, rs2b, rs3b, rdb, rs1valb, rs2valb, rs3valb, immvalb, rdvalb] = randomize(rs3=True)
         regsB = [rdb, rs1b, rs2b, rs3b]
         if compression == 2:
-          regsB = legalizecompr(regsB) 
+          regsB = legalizecompr(regsB)
       regsB[0] = regsA[regchoice]
-      
+
 
     case "raw":
       while (regsB[0] not in regsA):
@@ -770,9 +770,9 @@ def make_unique_hazard(test, regsA, haz_type='nohaz', regchoice=1):
   return regsA, regsB
 
 def randomize(rs1=None, rs2=None, rs3=None, allunique=True):
-    if rs1 is None: 
+    if rs1 is None:
       rs1 = randint(1, 31)
-    if rs2 is None: 
+    if rs2 is None:
       rs2 = randint(1, 31)
     if (rs3 is not None):
       rs3 = randint(1, 31)
@@ -897,7 +897,7 @@ def make_rd_corners(test, xlen, corners):
       [rs1, rs2, rd, rs1val, rs2val, immval, rdval] = randomize()
       desc = "cp_rd_corners (Test rd value = " + hex(v) + ")"
       while (legalizecompr(rd) == legalizecompr(rs2)):
-        rs2 = randint(0,31)   
+        rs2 = randint(0,31)
       if test in ["c.or","c.addw","c.xor"]:
         rd_temp = 0
         rs2_temp = v
@@ -910,7 +910,7 @@ def make_rd_corners(test, xlen, corners):
       elif test in ["c.sub","c.subw"]:
         rd_temp =  v>>1
         rs2_temp = (-v)>>1
-      writeCovVector(desc, rs1, rs2, rd, rd_temp, rs2_temp, 0, rdval, test, xlen)          
+      writeCovVector(desc, rs1, rs2, rd, rd_temp, rs2_temp, 0, rdval, test, xlen)
   elif test in crtype:
     for v in corners:
       [rs1, rs2, rd, rs1val, rs2val, immval, rdval] = randomize()
@@ -925,13 +925,13 @@ def make_rd_corners(test, xlen, corners):
       rdval = v - immval
       rdval &= 0xFFFFFFFFFFFFFFFF   # This prevents -ve decimal rdval (converts -10 to 18446744073709551606)
       writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen)
-  
+
   elif (test == "divw" or test == "divuw" or test=="mulw"):
     for v in corners:
       desc = "cp_rd_corners (Test rd value = " + hex(v) + ")"
       [rs1, rs2, rd, rs1val, rs2val, immval, rdval] = randomize()
       writeCovVector(desc, rs1, rs2, rd, v, 1, v, rdval, test, xlen)
-      
+
 
   elif (test == "c.lui"):
     for v in corners:
@@ -957,7 +957,7 @@ def make_rd_corners_lui(test, xlen, corners):
   for v in corners:
     [rs1, rs2, rd, rs1val, rs2val, immval, rdval] = randomize()
     desc = "cp_rd_corners_lui (Test rd value = " + hex(v) + ")"
-    writeCovVector(desc, rs1, rs2, rd,rs1val, rs2val, v>>12, rdval, test, xlen)   
+    writeCovVector(desc, rs1, rs2, rd,rs1val, rs2val, v>>12, rdval, test, xlen)
 
 def make_rd_rs1_eqval(test, xlen):
   [rs1, rs2, rd, rs1val, rs2val, immval, rdval] = randomize()
@@ -1042,7 +1042,7 @@ def make_j_imm_ones_zeros(test, xlen):
 def make_jalr_imm_ones_zeros(test, xlen):
 
   for i in range(0,12):
-    imm_value = 2**i # immediate value from 2^0 to 2^11        
+    imm_value = 2**i # immediate value from 2^0 to 2^11
     lines = "\n# Testcase cp_imm_ones_zeros bin " + str(i) + "_1 \n"
     lines = lines + "la x21, 1f\n" #load the address of the label '1' into x21
     lines = lines + "addi x21, x21, " + signedImm12(-imm_value, immOffset=True)  + "\n"
@@ -1077,7 +1077,7 @@ def make_offset(test, xlen):
   lines = lines + "3: nop # done with sequence\n"
   f.write(lines)
 
-def make_mem_hazard(test, xlen): 
+def make_mem_hazard(test, xlen):
   lines = "\n# Testcase mem_hazard (no dependency)\n"
   lines = lines + "la x1, scratch\n"
   lines = lines + test + " x2, 0(x1)\n"
@@ -1115,7 +1115,7 @@ def make_imm_shift(test, xlen):
     rng = range(1, xlen)
   else:
     rng = range(0, xlen)
-  
+
   for shift in rng:
     [rs1, rs2, rd, rs1val, rs2val, immval, rdval] = randomize()
     writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, shift, rdval, test, xlen)
@@ -1131,7 +1131,7 @@ def make_imm_mul(test, xlen):
     else:
       rng = range(-32,32)
   else:
-    rng = range(32) 
+    rng = range(32)
   for imm in rng:
     [rs1, rs2, rd, rs1val, rs2val, immval, rdval] = randomize()
     writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, imm, rdval, test, xlen)
@@ -1283,7 +1283,7 @@ def write_tests(coverpoints, test, xlen):
     elif (coverpoint == "cp_rs2_nx0"):
       make_rs2(test, xlen, range(1,32))
     elif (coverpoint == "cp_uimm"):
-      make_uimm(test, xlen) 
+      make_uimm(test, xlen)
     elif (coverpoint == "cmp_rd_rs1"):
       make_rd_rs1(test, xlen, range(32))
     elif (coverpoint == "cmp_rd_rs1_c"):
@@ -1387,11 +1387,11 @@ def write_tests(coverpoints, test, xlen):
       pass
     elif (coverpoint == "cp_imm_ones_zeros_jal"):
       make_j_imm_ones_zeros(test, xlen)
-    elif (coverpoint == "cp_rd_corners_sraiw"): 
+    elif (coverpoint == "cp_rd_corners_sraiw"):
       make_rd_corners(test,xlen,corners_sraiw)
     elif (coverpoint == "cp_imm_ones_zeros"):
       #cover point for jalr would still pass since it is getting covered by other instructions. But still testing it for satisfaction.
-      if (test == "jalr"): 
+      if (test == "jalr"):
         make_jalr_imm_ones_zeros(test, xlen)
     elif (coverpoint == "cp_imm_ones_zeros_addi4spn"):
        pass # not needed and seems to be covered by other things
@@ -1493,7 +1493,7 @@ def write_tests(coverpoints, test, xlen):
       make_imm5_corners(test, xlen)
     else:
       print("Warning: " + coverpoint + " not implemented yet for " + test)
-      
+
 def getcovergroups(coverdefdir, coverfiles):
   coverpoints = {}
   curinstr = ""
@@ -1519,7 +1519,7 @@ def getcovergroups(coverdefdir, coverfiles):
 ##################################
 
 # change these to suite your tests
-WALLY = os.environ.get('WALLY')
+ARCH_VERIF = os.path.abspath(os.path.join(sys.argv[0], ".."))
 rtype = ["add", "sub", "sll", "slt", "sltu", "xor", "srl", "sra", "or", "and",
         "addw", "subw", "sllw", "srlw", "sraw",
         "mul", "mulh", "mulhsu", "mulhu", "div", "divu", "rem", "remu",
@@ -1538,22 +1538,22 @@ shiftitype = ["slli", "srli", "srai"]
 shiftiwtype = ["slliw", "srliw", "sraiw"]
 itype = ["addi", "slti", "sltiu", "xori", "ori", "andi", "addiw"]
 ibtype = ["slli.uw","bclri","binvi","bseti","bexti","rori"]
-ibwtype = ["roriw"] 
+ibwtype = ["roriw"]
 stype = ["sb", "sh", "sw", "sd"]
 btype = ["beq", "bne", "blt", "bge", "bltu", "bgeu"]
 jtype = ["jal"]
 jalrtype = ["jalr"]
 utype = ["lui", "auipc"]
-fltype = ["flw", 
+fltype = ["flw",
           "flh",
           "fld"]
-fstype = ["fsw", 
+fstype = ["fsw",
           "fsh",
           "fsd"]
 F2Xtype = ["fcvt.w.s", "fcvt.wu.s", "fmv.x.w", "fcvt.l.s", "fcvt.lu.s",
             "fcvt.w.h", "fcvt.wu.h", "fmv.x.h", "fcvt.l.h", "fcvt.lu.h",
             "fcvt.w.d", "fcvt.wu.d", "fmv.x.d", "fcvt.l.d", "fcvt.lu.d", "fmvh.x.d", "fcvtmod.w.d"]
-fr4type = ["fmadd.s", "fmsub.s", "fnmadd.s", "fnmsub.s", 
+fr4type = ["fmadd.s", "fmsub.s", "fnmadd.s", "fnmsub.s",
             "fmadd.h", "fmsub.h", "fnmadd.h", "fnmsub.h",
             "fmadd.d", "fmsub.d", "fnmadd.d", "fnmsub.d"]
 frtype = ["fadd.s", "fsub.s", "fmul.s", "fdiv.s", "fsgnj.s", "fsgnjn.s", "fsgnjx.s", "fmax.s", "fmin.s", "fminm.s", "fmaxm.s",
@@ -1563,12 +1563,12 @@ fitype = ["fsqrt.s", "fround.s", "froundnx.s",
           "fsqrt.h", "fround.h", "froundnx.h",
           "fsqrt.d", "fround.d", "froundnx.d",
           "fcvt.s.h", "fcvt.h.s",
-          "fcvt.s.d", "fcvt.d.s", 
+          "fcvt.s.d", "fcvt.d.s",
           "fcvt.d.h", "fcvt.h.d"]
-fixtype = ["fclass.s", 
+fixtype = ["fclass.s",
             "fclass.h",
             "fclass.d"]
-X2Ftype = ["fcvt.s.w", "fcvt.s.wu", "fmv.w.x", "fcvt.s.l", "fcvt.s.lu", 
+X2Ftype = ["fcvt.s.w", "fcvt.s.wu", "fmv.w.x", "fcvt.s.l", "fcvt.s.lu",
             "fcvt.h.w", "fcvt.h.wu", "fmv.h.x", "fcvt.h.l", "fcvt.h.lu",
             "fcvt.d.w", "fcvt.d.wu", "fmv.d.x", "fcvt.d.l", "fcvt.d.lu"]
 PX2Ftype = ["fmvp.d.x"] # pair of integer registers to a single fp register
@@ -1606,7 +1606,7 @@ regconfig_xfff = F2Xtype + fcomptype + fixtype
 # instructions with fp first arg and the rest int args
 regconfig_fxxx = X2Ftype + PX2Ftype
 
-global hazardLabel 
+global hazardLabel
 hazardLabel = 1
 
 # for writeHazardVectors
@@ -1675,10 +1675,10 @@ if __name__ == '__main__':
   # map register encodings to literal values for fli.*
   flivals = { 0: -1.0,
               1: "min",
-              2: "0x1p-16", 
-              3: "0x1p-15", 
-              4: "0x1p-8", 
-              5: "0x1p-7", 
+              2: "0x1p-16",
+              3: "0x1p-15",
+              4: "0x1p-8",
+              5: "0x1p-7",
               6: 0.0625,
               7: 0.125,
               8: 0.25,
@@ -1726,8 +1726,8 @@ if __name__ == '__main__':
     if (xlen == 32):
       extensions += ["Zcf"]   # Add extensions which are specific to RV32
     for extension in extensions:
-      coverdefdir = WALLY+"/addins/cvw-arch-verif/fcov/rv"+str(xlen)
-      coverfiles = ["RV"+str(xlen)+extension] 
+      coverdefdir = f"{ARCH_VERIF}/fcov/rv{xlen}"
+      coverfiles = ["RV"+str(xlen)+extension]
       coverpoints = getcovergroups(coverdefdir, coverfiles)
       formatstrlen = str(int(xlen/4))
       formatstr = "0x{:0" + formatstrlen + "x}" # format as xlen-bit hexadecimal number
@@ -1763,15 +1763,15 @@ if __name__ == '__main__':
                                0x807fffff,
                                0x00400000,
                                0x80400000,
-                               0x00000001, 
-                               0x80000001, 
-                               0x7f800000, 
-                               0xff800000, 
-                               0x7fc00000, 
-                               0x7fffffff, 
-                               0x7f800001, 
-                               0x7fbfffff, 
-                               0x7ef8654f, 
+                               0x00000001,
+                               0x80000001,
+                               0x7f800000,
+                               0xff800000,
+                               0x7fc00000,
+                               0x7fffffff,
+                               0x7f800001,
+                               0x7fbfffff,
+                               0x7ef8654f,
                                0x813d9ab0]
       else:
         corners = corners + [0b0101101110111100100010000111011101100011101011101000011011110111, # random
@@ -1781,14 +1781,14 @@ if __name__ == '__main__':
                              0b0000000000000000000000000000000011111111111111111111111111111110, # Wmaxm1
                              0b0000000000000000000000000000000100000000000000000000000000000000, # Wmaxp1
                              0b0000000000000000000000000000000100000000000000000000000000000001] # Wmaxp2
-        
+
         corners_sraiw = [0b0000000000000000000000000000000000000000000000000000000000000000,
                          0b0000000000000000000000000000000000000000000000000000000000000001,
                          0b1111111111111111111111111111111111111111111111111111111111111111,
                          0b0000000000000000000000000000000001111111111111111111111111111111,
                          0b1111111111111111111111111111111110000000000000000000000000000000]
-        
-        
+
+
       corners_imm_12bits = [0, 1, 2, 1023, 1024, 2047, -2048, -2047, -2, -1]
       corners_16bits = [0, 1, 2, 2**(15), 2**(15)+1,2**(15)-1, 2**(15)-2, 2**(16)-1, 2**(16)-2,
                     0b0101010101010101, 0b1010101010101010, 0b0101101110111100, 0b1101101110111100]
@@ -1806,21 +1806,21 @@ if __name__ == '__main__':
                             0b01111111111111111111111111111111,0b01010101010101010101010101010101,
                             0b00101101110111100100010000111011]
       c_slli_64_corners  = [0x0000000000000000,0x0000000000000001,0x4000000000000000,0x0000000007fffffff,0x000000080000000,
-                            0x3FFFFFFFFFFFFFFF,0x7FFFFFFFFFFFFFFF,0x5555555555555555,0x2DDE443BB1D7437B] 
+                            0x3FFFFFFFFFFFFFFF,0x7FFFFFFFFFFFFFFF,0x5555555555555555,0x2DDE443BB1D7437B]
       c_srli_32_corners  = [0,2,4,0b11111111111111111111111111111110, 0b11111111111111111111111111111100,
                             0b10101010101010101010101010101010,0b10110111011110010001000011101110]
       c_srli_64_corners =  [0x000000000000000,0x00000000000000002,0x0000000000000004,0x00000001fffffffe,0x00000001fffffffc,
                             0x0000000200000000,0x0000000200000002,0xfffffffffffffffe,0xfffffffffffffffc,0xaaaaaaaaaaaaaaaa,
                             0xb77910eec75d0dee]
-      c_srai_32_corners  = [0,2,4,0b11111111111111111111111111111110, 0b00110111011110010001000011101110] 
+      c_srai_32_corners  = [0,2,4,0b11111111111111111111111111111110, 0b00110111011110010001000011101110]
       c_srai_64_corners  = [0x0000000000000000,0x0000000000000002,0x0000000000000004,0x00000001fffffffe,0x00000001fffffffc,
-                            0x0000000200000000,0x0000000200000002,0xfffffffffffffffe,0xfffffffffffffffc,0x377910eec75d0dee]               
-      
-      
-      fcorners = [0x00000000, 0x80000000, 0x3f800000, 0xbf800000, 0x3fc00000, 0xbfc00000, 0x40000000, 0xc0000000, 0x00800000, 
-                  0x80800000, 0x7f7fffff, 0xff7fffff, 0x007fffff, 0x807fffff, 0x00400000, 0x80400000, 0x00000001, 0x80000001, 
+                            0x0000000200000000,0x0000000200000002,0xfffffffffffffffe,0xfffffffffffffffc,0x377910eec75d0dee]
+
+
+      fcorners = [0x00000000, 0x80000000, 0x3f800000, 0xbf800000, 0x3fc00000, 0xbfc00000, 0x40000000, 0xc0000000, 0x00800000,
+                  0x80800000, 0x7f7fffff, 0xff7fffff, 0x007fffff, 0x807fffff, 0x00400000, 0x80400000, 0x00000001, 0x80000001,
                   0x7f800000, 0xff800000, 0x7fc00000, 0x7fffffff, 0x7f800001, 0x7fbfffff, 0x7ef8654f, 0x813d9ab0]
-      
+
       fcornersD = [0x0000000000000000,
                   0x8000000000000000,
                   0x3FF0000000000000,
@@ -1841,13 +1841,13 @@ if __name__ == '__main__':
                   0x8000000000000001,
                   0x7FF0000000000000,
                   0xFFF0000000000000,
-                  0x7FF8000000000000, 
+                  0x7FF8000000000000,
                   0x7FFFFFFFFFFFFFFF,
                   0x7FF0000000000001,
                   0x7FF7FFFFFFFFFFFF,
-                  0x5A392534A57711AD, 
+                  0x5A392534A57711AD,
                   0xA6E895993737426C]
-      
+
       fcornersH = [0x0000,
                    0x8000,
                    0x3C00,
@@ -1868,9 +1868,9 @@ if __name__ == '__main__':
                    0x8001,
                    0x7C00,
                    0xFC00,
-                   0x7E00, 
+                   0x7E00,
                    0x7FFF,
-                   0x7C01, 
+                   0x7C01,
                    0x7DFF,
                    0x58B4,
                    0xC93A]
@@ -1921,16 +1921,15 @@ if __name__ == '__main__':
                             0xfeef7FFF,
                             0xa1b27C01,
                             0x4fd77DFF]
-      
+
       # global NaNBox_tests
       NaNBox_tests = False
 
-      WALLY = os.environ.get('WALLY')
-      pathname = WALLY+"/addins/cvw-arch-verif/tests/rv" + str(xlen) + "/"+extension+"/"
+      pathname = f"{ARCH_VERIF}/tests/rv{xlen}/{extension}/"
       cmd = "mkdir -p " + pathname + " ; rm -f " + pathname + "/*" # make directory and remove old tests in dir
       os.system(cmd)
       for test in coverpoints.keys():
-        basename = "WALLY-COV-" + test 
+        basename = "WALLY-COV-" + test
         fname = pathname + "/" + basename + ".S"
 
         # print custom header part
@@ -1943,8 +1942,8 @@ if __name__ == '__main__':
         f.write(line)
 
         # insert generic header
-        h = open(WALLY+"/addins/cvw-arch-verif/templates/testgen_header.S", "r")
-        for line in h:  
+        h = open(f"{ARCH_VERIF}/templates/testgen_header.S", "r")
+        for line in h:
           f.write(line)
 
         # add assembly lines to enable fp where needed
@@ -1958,13 +1957,13 @@ if __name__ == '__main__':
         #  exit("Error: %s not implemented yet" % test)
         #else:
         #  write_rtype_arith_vectors(test, xlen)
-        write_tests(coverpoints[test], test, xlen) 
+        write_tests(coverpoints[test], test, xlen)
 
         # print footer
         line = "\n.EQU NUMTESTS," + str(1) + "\n\n"
         f.write(line)
-        h = open(WALLY+"/addins/cvw-arch-verif/templates/testgen_footer.S", "r")
-        for line in h:  
+        h = open(f"{ARCH_VERIF}/templates/testgen_footer.S", "r")
+        for line in h:
           f.write(line)
 
       # Finish


### PR DESCRIPTION
Use paths relative to the location of the scripts in cvw-arch-verif where possible instead of depending on the `$WALLY` variable. This allows almost all of the scripts to be run without being a cvw addin. The only remaining references to `$WALLY` are in the Makefile for the temporary virtual memory tests and in the `coverreport.py` script because our ucdb files are generated in `cvw/sim`.