### PR TITLE
fixed init lib path

### DIFF
--- a/tests/lockstep/priv/EndianM.S
+++ b/tests/lockstep/priv/EndianM.S
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 ///////////////////////////////////////////
 
-#include "../../WALLY-init-lib.h"
+#include "../../WALLY-init-lib.h" // This path needs to be updated if this file is relocated
 
 main:
 

--- a/tests/lockstep/priv/EndianM.S
+++ b/tests/lockstep/priv/EndianM.S
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 ///////////////////////////////////////////
 
-#include "../WALLY-init-lib.h"
+#include "../../WALLY-init-lib.h"
 
 main:
 

--- a/tests/lockstep/priv/ExceptionsInstr.S
+++ b/tests/lockstep/priv/ExceptionsInstr.S
@@ -10,7 +10,7 @@
 ///////////////////////////////////////////
 
 
-#include "../WALLY-init-lib.h"
+#include "../../WALLY-init-lib.h"
 
 main:
 

--- a/tests/lockstep/priv/ExceptionsInstr.S
+++ b/tests/lockstep/priv/ExceptionsInstr.S
@@ -10,7 +10,7 @@
 ///////////////////////////////////////////
 
 
-#include "../../WALLY-init-lib.h"
+#include "../../WALLY-init-lib.h" // This path needs to be updated if this file is relocated
 
 main:
 

--- a/tests/lockstep/priv/ExceptionsInstrC.S
+++ b/tests/lockstep/priv/ExceptionsInstrC.S
@@ -10,7 +10,7 @@
 ///////////////////////////////////////////
 
 
-#include "../WALLY-init-lib.h"
+#include "../../WALLY-init-lib.h"
 
 main:
 

--- a/tests/lockstep/priv/ExceptionsInstrC.S
+++ b/tests/lockstep/priv/ExceptionsInstrC.S
@@ -10,7 +10,7 @@
 ///////////////////////////////////////////
 
 
-#include "../../WALLY-init-lib.h"
+#include "../../WALLY-init-lib.h" // This path needs to be updated if this file is relocated
 
 main:
 

--- a/tests/lockstep/priv/ZicsrM.S
+++ b/tests/lockstep/priv/ZicsrM.S
@@ -11,7 +11,7 @@
 // General notes:
 // Use csrrw/csrrs/csrrc t6, csr, rs1    when modifying a CSR to also check the old value.
 
-#include "../WALLY-init-lib.h"
+#include "../../WALLY-init-lib.h" // This path needs to be updated if this file is relocated
 
 main:
 


### PR DESCRIPTION
Realized that after the privileged tests were restructured, the path to `WALLY-init-lib` was broken. It'd be a good idea to come up with a way to parameterize this value, but in the meantime, this is a fix to allow the tests to run again