### PR TITLE
Fix typo in file EndianM.S

### DIFF
--- a/tests/lockstep/priv/EndianM.S
+++ b/tests/lockstep/priv/EndianM.S
@@ -134,7 +134,7 @@ setendianness:
 1:  
     #ifdef __riscv_xlen
         #if __riscv_xlen == 64
-            csrrc t6, mstatus, s2   # for RV64, clear mstatus.MBE
+            csrrc t6, mstatus, s1   # for RV64, clear mstatus.MBE   
         #elif __riscv_xlen == 32
             csrrc t6, mstatush, s1  # for RV32, clear mstatush.MBE.
         #endif


### PR DESCRIPTION
Changed register on line 137 to use s1 instead of s2, as the MBE bit has been stored in s1 at the top of the file