### PR TITLE
Improved byte, half, word offset coverpoints for Endian{M/S/U} covergroups

### DIFF
--- a/fcov/priv/EndianM_coverage.svh
+++ b/fcov/priv/EndianM_coverage.svh
@@ -51,13 +51,16 @@ covergroup EndianM_endian_cg with function sample(ins_endianm_t ins);
     cp_lbu: coverpoint ins.current.insn {
         wildcard bins lbu = {32'b????????????_?????_100_?????_0000011}; 
     }
-    cp_byteoffset: coverpoint ins.current.imm[2:0] iff (ins.current.rs1_val[2:0] == 3'b000) {
+    cp_byteoffset: coverpoint {ins.current.imm + ins.current.rs1_val}[2:0] {
         // all byte offsets
     }
-    cp_halfoffset: coverpoint ins.current.imm[2:1] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[0] == 1'b0)  {
+    cp_halfoffset: coverpoint {ins.current.imm + ins.current.rs1_val}[2:0] {
+        wildcard ignore_bins lsb = {3'b??1};
         // all halfword offsets
     }    
-    cp_wordoffset: coverpoint ins.current.imm[2] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[1:0] == 2'b00)  {
+    cp_wordoffset: coverpoint {ins.current.imm + ins.current.rs1_val}[2:0] {
+        wildcard ignore_bins b0 = {3'b??1}; 
+        wildcard ignore_bins b2 = {3'b?1?}; 
         // all word offsets
     }    
     `ifdef XLEN64

--- a/fcov/priv/EndianS_coverage.svh
+++ b/fcov/priv/EndianS_coverage.svh
@@ -53,13 +53,16 @@ covergroup EndianS_endian_cg with function sample(ins_endians_t ins);
     cp_lbu: coverpoint ins.current.insn {
         wildcard bins lbu = {32'b????????????_?????_100_?????_0000011}; 
     }
-    cp_byteoffset: coverpoint ins.current.imm[2:0] iff (ins.current.rs1_val[2:0] == 3'b000) {
+    cp_byteoffset: coverpoint {ins.current.imm + ins.current.rs1_val}[2:0] {
         // all byte offsets
     }
-    cp_halfoffset: coverpoint ins.current.imm[2:1] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[0] == 1'b0)  {
+    cp_halfoffset: coverpoint {ins.current.imm + ins.current.rs1_val}[2:0] {
+        wildcard ignore_bins lsb = {3'b??1};
         // all halfword offsets
     }    
-    cp_wordoffset: coverpoint ins.current.imm[2] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[1:0] == 2'b00)  {
+    cp_wordoffset: coverpoint {ins.current.imm + ins.current.rs1_val}[2:0] {
+        wildcard ignore_bins b0 = {3'b??1}; 
+        wildcard ignore_bins b2 = {3'b?1?}; 
         // all word offsets
     }    
     `ifdef XLEN64

--- a/fcov/priv/EndianU_coverage.svh
+++ b/fcov/priv/EndianU_coverage.svh
@@ -52,15 +52,18 @@ covergroup EndianU_endian_cg with function sample(ins_endianu_t ins);
     cp_lbu: coverpoint ins.current.insn {
         wildcard bins lbu = {32'b????????????_?????_100_?????_0000011}; 
     }
-    cp_byteoffset: coverpoint ins.current.imm[2:0] iff (ins.current.rs1_val[2:0] == 3'b000) {
+    cp_byteoffset: coverpoint {ins.current.imm + ins.current.rs1_val}[2:0] {
         // all byte offsets
     }
-    cp_halfoffset: coverpoint ins.current.imm[2:1] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[0] == 1'b0)  {
+    cp_halfoffset: coverpoint {ins.current.imm + ins.current.rs1_val}[2:0] {
+        wildcard ignore_bins lsb = {3'b??1};
         // all halfword offsets
     }    
-    cp_wordoffset: coverpoint ins.current.imm[2] iff (ins.current.rs1_val[2:0] == 3'b000 & ins.current.imm[1:0] == 2'b00)  {
+    cp_wordoffset: coverpoint {ins.current.imm + ins.current.rs1_val}[2:0] {
+        wildcard ignore_bins b0 = {3'b??1}; 
+        wildcard ignore_bins b2 = {3'b?1?}; 
         // all word offsets
-    }    
+    }     
     priv_mode_u: coverpoint ins.current.mode {
        bins U_mode = {2'b00};
     }


### PR DESCRIPTION
Changed cp_{byte/half/word}offset to include valid offsets where imm[2:0] is not necessarily zero. I did this by checking the bottom 3 bits of the sum of imm and rs1_val and using wildcard ignore_bins to exclude auto-bins where bit 0 is 1 (for half word offset) and where either bit 0 or 1 is one (for word offset). This gives the following auto-bins in the report:

```
    Coverpoint cp_byteoffset                          100.00%        100          -    Covered              
        covered/total bins:                                 8          8          -                      
        missing/total bins:                                 0          8          -                      
        % Hit:                                        100.00%        100          -                      
        bin auto[0]                                      1323          1          -    Covered              
        bin auto[1]                                       231          1          -    Covered              
        bin auto[2]                                       248          1          -    Covered              
        bin auto[3]                                       185          1          -    Covered              
        bin auto[4]                                       350          1          -    Covered              
        bin auto[5]                                       225          1          -    Covered              
        bin auto[6]                                       230          1          -    Covered              
        bin auto[7]                                       246          1          -    Covered              
    Coverpoint cp_halfoffset                          100.00%        100          -    Covered              
        covered/total bins:                                 4          4          -                      
        missing/total bins:                                 0          4          -                      
        % Hit:                                        100.00%        100          -                      
        ignore_bin lsb                                    887                     -    Occurred             
        bin auto[0]                                      1323          1          -    Covered              
        bin auto[2]                                       248          1          -    Covered              
        bin auto[4]                                       350          1          -    Covered              
        bin auto[6]                                       230          1          -    Covered              
    Coverpoint cp_wordoffset                          100.00%        100          -    Covered              
        covered/total bins:                                 2          2          -                      
        missing/total bins:                                 0          2          -                      
        % Hit:                                        100.00%        100          -                      
        ignore_bin b0                                     887                     -    Occurred             
        ignore_bin b2                                     909                     -    Occurred             
        bin auto[0]                                      1323          1          -    Covered              
        bin auto[4]                                       350          1          -    Covered
```

resolves #425 