### PR TITLE
Renamed covergroups

### DIFF
--- a/fcov/priv/ZicntrM_coverage.svh
+++ b/fcov/priv/ZicntrM_coverage.svh
@@ -23,7 +23,7 @@
 `define COVER_ZICNTRM
 typedef RISCV_instruction #(ILEN, XLEN, FLEN, VLEN, NHART, RETIRE) ins_zicntrm_t;
 
-covergroup mcounters_cg with function sample(ins_zicntrm_t ins);
+covergroup ZicntrM_mcounters_cg with function sample(ins_zicntrm_t ins);
     option.per_instance = 0; 
     // Counter access in machine mode
 
@@ -392,6 +392,6 @@ function void zicntrm_sample(int hart, int issue);
     ins.add_rs1(2);
     ins.add_csr(1);
     
-    mcounters_cg.sample(ins);
+    ZicntrM_mcounters_cg.sample(ins);
     
 endfunction

--- a/fcov/priv/ZicntrM_coverage_init.svh
+++ b/fcov/priv/ZicntrM_coverage_init.svh
@@ -8,4 +8,4 @@
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-    mcounters_cg = new();         mcounters_cg.set_inst_name("obj_mcounters");
+    ZicntrM_mcounters_cg = new();         ZicntrM_mcounters_cg.set_inst_name("obj_mcounters");

--- a/fcov/priv/ZicntrS_coverage.svh
+++ b/fcov/priv/ZicntrS_coverage.svh
@@ -23,7 +23,7 @@
 `define COVER_ZICNTRS
 typedef RISCV_instruction #(ILEN, XLEN, FLEN, VLEN, NHART, RETIRE) ins_zicntrs_t;
 
-covergroup scounters_cg with function sample(ins_zicntrs_t ins);
+covergroup ZicntrS_scounters_cg with function sample(ins_zicntrs_t ins);
     option.per_instance = 0; 
     // counter access in supervisor mode
 
@@ -408,6 +408,6 @@ function void zicntrs_sample(int hart, int issue);
     ins.add_rs1(2);
     ins.add_csr(1);
     
-    scounters_cg.sample(ins);
+    ZicntrS_scounters_cg.sample(ins);
     
 endfunction

--- a/fcov/priv/ZicntrS_coverage_init.svh
+++ b/fcov/priv/ZicntrS_coverage_init.svh
@@ -8,4 +8,4 @@
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-    scounters_cg = new();         scounters_cg.set_inst_name("obj_zicntrs");
+    ZicntrS_scounters_cg = new();         ZicntrS_scounters_cg.set_inst_name("obj_zicntrs");

--- a/fcov/priv/ZicntrU_coverage.svh
+++ b/fcov/priv/ZicntrU_coverage.svh
@@ -24,7 +24,7 @@
 typedef RISCV_instruction #(ILEN, XLEN, FLEN, VLEN, NHART, RETIRE) ins_zicntru_t;
 
 
-covergroup ucounters_cg with function sample(ins_zicntru_t ins);
+covergroup ZicntrU_ucounters_cg with function sample(ins_zicntru_t ins);
     option.per_instance = 0; 
     // Counter access in user mode 
 
@@ -268,6 +268,6 @@ function void zicntru_sample(int hart, int issue);
     ins.add_rs1(2);
     ins.add_csr(1);
 
-    ucounters_cg.sample(ins);
+    ZicntrU_ucounters_cg.sample(ins);
 
 endfunction

--- a/fcov/priv/ZicntrU_coverage_init.svh
+++ b/fcov/priv/ZicntrU_coverage_init.svh
@@ -8,4 +8,4 @@
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-    ucounters_cg = new();         ucounters_cg.set_inst_name("obj_zicntru");
+    ZicntrU_ucounters_cg = new();         ZicntrU_ucounters_cg.set_inst_name("obj_zicntru");


### PR DESCRIPTION
Renamed counter covergroups to be consistent with other covergroups by prepending the test plan name. 