### PR TITLE
Fixed bit swizzled bins

### DIFF
--- a/fcov/priv/ExceptionsM_coverage.svh
+++ b/fcov/priv/ExceptionsM_coverage.svh
@@ -51,12 +51,12 @@ covergroup ExceptionsM_exceptions_cg with function sample(ins_exceptionsm_t ins)
                                    ins.current.rs1_val == ins.current.rs2_val,                  // A == B  
                                    $signed(ins.current.rs1_val) < $signed(ins.current.rs2_val), // A < B (signed)
                                    $unsigned(ins.current.rs1_val) < $unsigned(ins.current.rs2_val)} {                 // A < B (unsigned)
-        wildcard bins beq_nottaken  = {3'b000_0_?_?};
-        wildcard bins bne_nottaken  = {3'b001_1_?_?};
-        wildcard bins blt_nottaken  = {3'b100_?_0_?};
-        wildcard bins bge_nottaken  = {3'b101_?_1_?};
-        wildcard bins bltu_nottaken = {3'b110_?_?_0};
-        wildcard bins bgeu_nottaken = {3'b111_?_?_1};
+        wildcard bins beq_nottaken  = {6'b000_0_?_?};
+        wildcard bins bne_nottaken  = {6'b001_1_?_?};
+        wildcard bins blt_nottaken  = {6'b100_?_0_?};
+        wildcard bins bge_nottaken  = {6'b101_?_1_?};
+        wildcard bins bltu_nottaken = {6'b110_?_?_0};
+        wildcard bins bgeu_nottaken = {6'b111_?_?_1};
     }
     jal: coverpoint ins.current.insn {
         wildcard bins jal = {32'b????????????????????_?????_1101111};

--- a/fcov/priv/ExceptionsS_coverage.svh
+++ b/fcov/priv/ExceptionsS_coverage.svh
@@ -35,27 +35,28 @@ covergroup ExceptionsS_exceptions_cg with function sample(ins_exceptionss_t ins)
     }
     // TODO: This contains bit swizzling and the assumption that the  'bit' type is by default unsigned
     //       we aught to test this for a sanity check to both of these assumptions
-    branches_taken: coverpoint {ins.current.insn[14:12],                                           // funct3
-                                ins.current.rs1_val == ins.current.rs2_val,                        // A == B  
-                                $signed(ins.current.rs1_val) < $signed(ins.current.rs2_val),       // A < B (signed)
-                                $unsigned(ins.current.rs1_val) < $unsigned(ins.current.rs2_val)} { // A < B (unsigned)
-        wildcard bins beq_taken  = {3'b000, 1'b1, 1'b?, 1'b?};
-        wildcard bins bne_taken  = {3'b001, 1'b0, 1'b?, 1'b?};
-        wildcard bins blt_taken  = {3'b100, 1'b?, 1'b1, 1'b?};
-        wildcard bins bge_taken  = {3'b101, 1'b?, 1'b0, 1'b?};
-        wildcard bins bltu_taken = {3'b110, 1'b?, 1'b?, 1'b1};
-        wildcard bins bgeu_taken = {3'b111, 1'b?, 1'b?, 1'b0};
+    branches_taken: coverpoint {ins.current.insn[14:12],                                     // funct3
+                                ins.current.rs1_val == ins.current.rs2_val,                  // A = B  
+                                $signed(ins.current.rs1_val) < $signed(ins.current.rs2_val), // A < B (signed)
+                                $unsigned(ins.current.rs1_val) < $unsigned(ins.current.rs2_val)} {                 // A < B (unsigned)
+        //wildcard bins beq_taken  = {3'b000, 1'b1, 1'b?, 1'b?};
+        wildcard bins beq_taken  = {6'b000_1_?_?};
+        wildcard bins bne_taken  = {6'b001_0_?_?};
+        wildcard bins blt_taken  = {6'b100_?_1_?};
+        wildcard bins bge_taken  = {6'b101_?_0_?};
+        wildcard bins bltu_taken = {6'b110_?_?_1};
+        wildcard bins bgeu_taken = {6'b111_?_?_0};
     }
-    branches_nottaken: coverpoint {ins.current.insn[14:12],                                           // funct3
-                                   ins.current.rs1_val == ins.current.rs2_val,                        // A == B  
-                                   $signed(ins.current.rs1_val) < $signed(ins.current.rs2_val),       // A < B (signed)
-                                   $unsigned(ins.current.rs1_val) < $unsigned(ins.current.rs2_val)} { // A < B (unsigned)
-        wildcard bins beq_nottaken  = {3'b000, 1'b0, 1'b?, 1'b?};
-        wildcard bins bne_nottaken  = {3'b001, 1'b1, 1'b?, 1'b?};
-        wildcard bins blt_nottaken  = {3'b100, 1'b?, 1'b0, 1'b?};
-        wildcard bins bge_nottaken  = {3'b101, 1'b?, 1'b1, 1'b?};
-        wildcard bins bltu_nottaken = {3'b110, 1'b?, 1'b?, 1'b0};
-        wildcard bins bgeu_nottaken = {3'b111, 1'b?, 1'b?, 1'b1};
+    branches_nottaken: coverpoint {ins.current.insn[14:12],                                     // funct3
+                                   ins.current.rs1_val == ins.current.rs2_val,                  // A == B  
+                                   $signed(ins.current.rs1_val) < $signed(ins.current.rs2_val), // A < B (signed)
+                                   $unsigned(ins.current.rs1_val) < $unsigned(ins.current.rs2_val)} {                 // A < B (unsigned)
+        wildcard bins beq_nottaken  = {6'b000_0_?_?};
+        wildcard bins bne_nottaken  = {6'b001_1_?_?};
+        wildcard bins blt_nottaken  = {6'b100_?_0_?};
+        wildcard bins bge_nottaken  = {6'b101_?_1_?};
+        wildcard bins bltu_nottaken = {6'b110_?_?_0};
+        wildcard bins bgeu_nottaken = {6'b111_?_?_1};
     }
     jal: coverpoint ins.current.insn {
         wildcard bins jal = {32'b????????????????????_?????_1101111};

--- a/fcov/priv/ExceptionsU_coverage.svh
+++ b/fcov/priv/ExceptionsU_coverage.svh
@@ -38,24 +38,25 @@ covergroup ExceptionsU_exceptions_cg with function sample(ins_exceptionsu_t ins)
     branches_taken: coverpoint {ins.current.insn[14:12],                                     // funct3
                                 ins.current.rs1_val == ins.current.rs2_val,                  // A = B  
                                 $signed(ins.current.rs1_val) < $signed(ins.current.rs2_val), // A < B (signed)
-                                ins.current.rs1_val < ins.current.rs2_val} {                 // A < B (unsigned)
-        wildcard bins beq_taken  = {3'b000, 1'b1, 1'b?, 1'b?};
-        wildcard bins bne_taken  = {3'b001, 1'b0, 1'b?, 1'b?};
-        wildcard bins blt_taken  = {3'b100, 1'b?, 1'b1, 1'b?};
-        wildcard bins bge_taken  = {3'b101, 1'b?, 1'b0, 1'b?};
-        wildcard bins bltu_taken = {3'b110, 1'b?, 1'b?, 1'b1};
-        wildcard bins bgeu_taken = {3'b111, 1'b?, 1'b?, 1'b0};
+                                $unsigned(ins.current.rs1_val) < $unsigned(ins.current.rs2_val)} {                 // A < B (unsigned)
+        //wildcard bins beq_taken  = {3'b000, 1'b1, 1'b?, 1'b?};
+        wildcard bins beq_taken  = {6'b000_1_?_?};
+        wildcard bins bne_taken  = {6'b001_0_?_?};
+        wildcard bins blt_taken  = {6'b100_?_1_?};
+        wildcard bins bge_taken  = {6'b101_?_0_?};
+        wildcard bins bltu_taken = {6'b110_?_?_1};
+        wildcard bins bgeu_taken = {6'b111_?_?_0};
     }
     branches_nottaken: coverpoint {ins.current.insn[14:12],                                     // funct3
                                    ins.current.rs1_val == ins.current.rs2_val,                  // A == B  
                                    $signed(ins.current.rs1_val) < $signed(ins.current.rs2_val), // A < B (signed)
-                                   ins.current.rs1_val < ins.current.rs2_val} {                 // A < B (unsigned)
-        wildcard bins beq_nottaken  = {3'b000, 1'b0, 1'b?, 1'b?};
-        wildcard bins bne_nottaken  = {3'b001, 1'b1, 1'b?, 1'b?};
-        wildcard bins blt_nottaken  = {3'b100, 1'b?, 1'b0, 1'b?};
-        wildcard bins bge_nottaken  = {3'b101, 1'b?, 1'b1, 1'b?};
-        wildcard bins bltu_nottaken = {3'b110, 1'b?, 1'b?, 1'b0};
-        wildcard bins bgeu_nottaken = {3'b111, 1'b?, 1'b?, 1'b1};
+                                   $unsigned(ins.current.rs1_val) < $unsigned(ins.current.rs2_val)} {                 // A < B (unsigned)
+        wildcard bins beq_nottaken  = {6'b000_0_?_?};
+        wildcard bins bne_nottaken  = {6'b001_1_?_?};
+        wildcard bins blt_nottaken  = {6'b100_?_0_?};
+        wildcard bins bge_nottaken  = {6'b101_?_1_?};
+        wildcard bins bltu_nottaken = {6'b110_?_?_0};
+        wildcard bins bgeu_nottaken = {6'b111_?_?_1};
     }
     jal: coverpoint ins.current.insn {
         wildcard bins jal = {32'b????????????????????_?????_1101111};


### PR DESCRIPTION
Bit swizzled bins for taken and not taken branches are never hit. @C0d3ing fixed this in one of the three exceptions files by concatenating the values into a single 6 bit binary literal. This applies those changes throughout. 