### PR TITLE
Add standard coverpoint file and update priv mode to use prev

### DIFF
--- a/fcov/coverage/RISCV_coverage_standard_coverpoints.svh
+++ b/fcov/coverage/RISCV_coverage_standard_coverpoints.svh
@@ -1,0 +1,47 @@
+///////////////////////////////////////////
+//
+// RISC-V Architectural Functional Coverage Standard Covergroups
+//
+// Written: Jordan Carlin jcarlin@hmc.edu 6 March 2025
+// 
+// Copyright (C) 2024 Harvey Mudd College, 10x Engineers, UET Lahore
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the “License”); you may not use this file 
+// except in compliance with the License, or, at your option, the Apache License version 2.0. You 
+// may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work distributed under the 
+// License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+// either express or implied. See the License for the specific language governing permissions 
+// and limitations under the License.
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+  // Privilege mode coverpoints
+  // Uses ins.prev to check mode at end of previous instruction,
+  // which is the mode the current instruction begins execution in
+  priv_mode_m: coverpoint ins.prev.mode { 
+    bins M_mode = {2'b11};
+  }
+  priv_mode_s: coverpoint ins.prev.mode { 
+    bins S_mode = {2'b01};
+  }
+  priv_mode_u: coverpoint ins.prev.mode { 
+    bins U_mode = {2'b00};
+  }
+  priv_mode_su: coverpoint ins.prev.mode {
+    bins S_mode = {2'b01};
+    bins U_mode = {2'b00};
+  }
+  priv_mode_msu: coverpoint ins.prev.mode {
+    bins M_mode = {2'b11};
+    bins S_mode = {2'b01};
+    bins U_mode = {2'b00};
+  }
+  priv_mode_mu: coverpoint ins.prev.mode {
+    bins M_mode = {2'b11};
+    bins U_mode = {2'b00};
+  }

--- a/fcov/coverage/RISCV_coverage_standard_coverpoints.svh
+++ b/fcov/coverage/RISCV_coverage_standard_coverpoints.svh
@@ -3,45 +3,51 @@
 // RISC-V Architectural Functional Coverage Standard Covergroups
 //
 // Written: Jordan Carlin jcarlin@hmc.edu 6 March 2025
-// 
+//
 // Copyright (C) 2024 Harvey Mudd College, 10x Engineers, UET Lahore
 //
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// Licensed under the Solderpad Hardware License v 2.1 (the “License”); you may not use this file 
-// except in compliance with the License, or, at your option, the Apache License version 2.0. You 
+// Licensed under the Solderpad Hardware License v 2.1 (the “License”); you may not use this file
+// except in compliance with the License, or, at your option, the Apache License version 2.0. You
 // may obtain a copy of the License at
 //
 // https://solderpad.org/licenses/SHL-2.1/
 //
-// Unless required by applicable law or agreed to in writing, any work distributed under the 
-// License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
-// either express or implied. See the License for the specific language governing permissions 
+// Unless required by applicable law or agreed to in writing, any work distributed under the
+// License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions
 // and limitations under the License.
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
   // Privilege mode coverpoints
   // Uses ins.prev to check mode at end of previous instruction,
   // which is the mode the current instruction begins execution in
-  priv_mode_m: coverpoint ins.prev.mode { 
+  priv_mode_m: coverpoint ins.prev.mode {
+    type_option.weight = 0;
     bins M_mode = {2'b11};
   }
-  priv_mode_s: coverpoint ins.prev.mode { 
+  priv_mode_s: coverpoint ins.prev.mode {
+    type_option.weight = 0;
     bins S_mode = {2'b01};
   }
-  priv_mode_u: coverpoint ins.prev.mode { 
+  priv_mode_u: coverpoint ins.prev.mode {
+    type_option.weight = 0;
     bins U_mode = {2'b00};
   }
   priv_mode_su: coverpoint ins.prev.mode {
+    type_option.weight = 0;
     bins S_mode = {2'b01};
     bins U_mode = {2'b00};
   }
   priv_mode_msu: coverpoint ins.prev.mode {
+    type_option.weight = 0;
     bins M_mode = {2'b11};
     bins S_mode = {2'b01};
     bins U_mode = {2'b00};
   }
   priv_mode_mu: coverpoint ins.prev.mode {
+    type_option.weight = 0;
     bins M_mode = {2'b11};
     bins U_mode = {2'b00};
   }

--- a/fcov/coverage/RISCV_coverage_standard_coverpoints.svh
+++ b/fcov/coverage/RISCV_coverage_standard_coverpoints.svh
@@ -35,6 +35,16 @@
     type_option.weight = 0;
     bins U_mode = {2'b00};
   }
+  priv_mode_ms: coverpoint ins.prev.mode {
+    type_option.weight = 0;
+    bins M_mode = {2'b11};
+    bins S_mode = {2'b01};
+  }
+  priv_mode_mu: coverpoint ins.prev.mode {
+    type_option.weight = 0;
+    bins M_mode = {2'b11};
+    bins U_mode = {2'b00};
+  }
   priv_mode_su: coverpoint ins.prev.mode {
     type_option.weight = 0;
     bins S_mode = {2'b01};
@@ -44,10 +54,5 @@
     type_option.weight = 0;
     bins M_mode = {2'b11};
     bins S_mode = {2'b01};
-    bins U_mode = {2'b00};
-  }
-  priv_mode_mu: coverpoint ins.prev.mode {
-    type_option.weight = 0;
-    bins M_mode = {2'b11};
     bins U_mode = {2'b00};
   }

--- a/fcov/priv/EndianM_coverage.svh
+++ b/fcov/priv/EndianM_coverage.svh
@@ -20,7 +20,8 @@
 
 `define COVER_ENDIANM
 covergroup EndianM_endian_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
     // "Endianness tests in machine mode"
 
     // building blocks for the main coverpoints
@@ -68,9 +69,6 @@ covergroup EndianM_endian_cg with function sample(ins_t ins);
         mstatus_mbe: coverpoint ins.current.csr[12'h310][5] { // mbe is mstatush[5] in RV32
         }
     `endif
-    priv_mode_m: coverpoint ins.current.mode { 
-       bins M_mode = {2'b11};
-    }   
     // main coverpoints
     cp_mstatus_mbe_endianness_sw: cross priv_mode_m, mstatus_mbe, cp_sw, cp_wordoffset;
     cp_mstatus_mbe_endianness_sh: cross priv_mode_m, mstatus_mbe, cp_sh, cp_halfoffset;

--- a/fcov/priv/EndianS_coverage.svh
+++ b/fcov/priv/EndianS_coverage.svh
@@ -22,7 +22,8 @@
 
 `define COVER_ENDIANS
 covergroup EndianS_endian_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
     // "Endianness tests in machine mode"
 
     // building blocks for the main coverpoints
@@ -78,16 +79,7 @@ covergroup EndianS_endian_cg with function sample(ins_t ins);
         }
     `endif
     sstatus_ube: coverpoint ins.current.csr[12'h100][6] { // ube is mstatus[6]
-    }
-    priv_mode_m: coverpoint ins.current.mode { 
-       bins M_mode = {2'b11};
-    }   
-    priv_mode_s: coverpoint ins.current.mode { 
-       bins S_mode = {2'b01};
-    }
-    priv_mode_u: coverpoint ins.current.mode { 
-       bins U_mode = {2'b00};
-    }   
+    } 
     mstatus_mprv: coverpoint ins.current.csr[12'h300][17] { // mprv is mstatus[17]
     }
     mstatus_mpp: coverpoint ins.current.csr[12'h300][12:11] { // mpp is mstatus[12:11]

--- a/fcov/priv/EndianU_coverage.svh
+++ b/fcov/priv/EndianU_coverage.svh
@@ -22,7 +22,8 @@
 
 `define COVER_ENDIANU
 covergroup EndianU_endian_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
     // "Endianness tests in user mode"
 
     // building blocks for the main coverpoints
@@ -62,12 +63,6 @@ covergroup EndianU_endian_cg with function sample(ins_t ins);
         wildcard ignore_bins b2 = {3'b?1?}; 
         // all word offsets
     }     
-    priv_mode_u: coverpoint ins.current.mode {
-        bins U_mode = {2'b00};
-    }
-    priv_mode_m: coverpoint ins.current.mode {
-        bins M_mode = {2'b11};
-    }
     mstatus_ube: coverpoint ins.current.csr[12'h300][6] { // ube is mstatus[6]
     }
     mstatus_mprv: coverpoint ins.current.csr[12'h300][17] { // mprv is mstatus[17]

--- a/fcov/priv/ExceptionsM_coverage.svh
+++ b/fcov/priv/ExceptionsM_coverage.svh
@@ -22,8 +22,8 @@
 
 `define COVER_EXCEPTIONSM
 covergroup ExceptionsM_exceptions_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
-
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
     // building blocks for the main coverpoints
     ecall: coverpoint ins.current.insn {
         bins ecall  = {32'h00000073};
@@ -105,9 +105,6 @@ covergroup ExceptionsM_exceptions_cg with function sample(ins_t ins);
     }
     mstatus_MIE: coverpoint ins.prev.csr[12'h300][3] {
         // auto fills 1 and 0
-    }
-    priv_mode_m: coverpoint ins.current.mode {
-       bins M_mode = {2'b11};
     }
     pc_bit_1: coverpoint ins.current.pc_rdata[1] {
         bins zero = {0};

--- a/fcov/priv/ExceptionsS_coverage.svh
+++ b/fcov/priv/ExceptionsS_coverage.svh
@@ -22,7 +22,8 @@
 
 `define COVER_EXCEPTIONSS
 covergroup ExceptionsS_exceptions_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
 
     // building blocks for the main coverpoints
     ecall: coverpoint ins.current.insn {
@@ -116,21 +117,6 @@ covergroup ExceptionsS_exceptions_cg with function sample(ins_t ins);
     }
     sstatus_SIE: coverpoint ins.prev.csr[12'h100][1] {
         // auto fills 1 and 0
-    }
-    priv_mode_s: coverpoint ins.current.mode {
-        bins S_mode = {2'b01};
-    }
-    priv_mode_m: coverpoint ins.current.mode {
-        bins M_mode = {2'b11};
-    }
-    priv_mode_su: coverpoint ins.current.mode {
-        bins S_mode = {2'b01};
-        bins U_mode = {2'b00};
-    }
-    priv_mode_sum: coverpoint ins.current.mode {
-        bins M_mode = {2'b11};
-        bins S_mode = {2'b01};
-        bins U_mode = {2'b00};
     }
     pc_bit_1: coverpoint ins.current.pc_rdata[1] {
         bins zero = {0};

--- a/fcov/priv/ExceptionsU_coverage.svh
+++ b/fcov/priv/ExceptionsU_coverage.svh
@@ -22,7 +22,8 @@
 
 `define COVER_EXCEPTIONSU
 covergroup ExceptionsU_exceptions_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
 
     // building blocks for the main coverpoints
     ecall: coverpoint ins.current.insn {
@@ -111,9 +112,6 @@ covergroup ExceptionsU_exceptions_cg with function sample(ins_t ins);
     }
     mstatus_SIE: coverpoint ins.prev.csr[12'h300][1] {
         // auto fills 1 and 0
-    }
-    priv_mode_u: coverpoint ins.current.mode {
-       bins U_mode = {2'b00};
     }
     medelegb8: coverpoint ins.current.csr[12'h302][8]{
     }

--- a/fcov/priv/ExceptionsZicboS_coverage.svh
+++ b/fcov/priv/ExceptionsZicboS_coverage.svh
@@ -22,7 +22,8 @@
 
 `define COVER_EXCEPTIONSZICBOS
 covergroup ExceptionsZicboS_exceptions_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
 
     // building blocks for the main coverpoints
     cbo_inval: coverpoint ins.current.insn {
@@ -49,16 +50,11 @@ covergroup ExceptionsZicboS_exceptions_cg with function sample(ins_t ins);
     }
     senvcfg_cbze: coverpoint ins.current.csr[12'h10A][7] {
     }
-    priv_modes: coverpoint ins.current.mode {
-        bins U_mode = {2'b00};
-        bins S_mode = {2'b01};
-        bins M_mode = {2'b11};
-    }
 
     // main coverpoints
-    cp_cbie:  cross cbo_inval,      menvcfg_cbie,  senvcfg_cbie,  priv_modes;
-    cp_cbcfe: cross cbo_flushclean, menvcfg_cbcfe, senvcfg_cbcfe, priv_modes;
-    cp_cbze:  cross cbo_zero,       menvcfg_cbze,  senvcfg_cbze,  priv_modes;
+    cp_cbie:  cross cbo_inval,      menvcfg_cbie,  senvcfg_cbie,  priv_mode_sum;
+    cp_cbcfe: cross cbo_flushclean, menvcfg_cbcfe, senvcfg_cbcfe, priv_mode_sum;
+    cp_cbze:  cross cbo_zero,       menvcfg_cbze,  senvcfg_cbze,  priv_mode_sum;
 
 endgroup
 

--- a/fcov/priv/ExceptionsZicboU_coverage.svh
+++ b/fcov/priv/ExceptionsZicboU_coverage.svh
@@ -22,7 +22,8 @@
 
 `define COVER_EXCEPTIONSZICBOU
 covergroup ExceptionsZicboU_exceptions_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
 
     // building blocks for the main coverpoints
     cbo_inval: coverpoint ins.current.insn {
@@ -42,15 +43,11 @@ covergroup ExceptionsZicboU_exceptions_cg with function sample(ins_t ins);
     }
     menvcfg_cbze: coverpoint ins.current.csr[12'h30A][7] {
     }
-    priv_modes: coverpoint ins.current.mode {
-        bins U_mode = {2'b00};
-        bins M_mode = {2'b11};
-    }
 
     // main coverpoints
-    cp_cbie:  cross cbo_inval,      menvcfg_cbie,  priv_modes;
-    cp_cbcfe: cross cbo_flushclean, menvcfg_cbcfe, priv_modes;
-    cp_cbze:  cross cbo_zero,       menvcfg_cbze,  priv_modes;
+    cp_cbie:  cross cbo_inval,      menvcfg_cbie,  priv_mode_mu;
+    cp_cbcfe: cross cbo_flushclean, menvcfg_cbcfe, priv_mode_mu;
+    cp_cbze:  cross cbo_zero,       menvcfg_cbze,  priv_mode_mu;
 
 endgroup
 

--- a/fcov/priv/InterruptsM_coverage.svh
+++ b/fcov/priv/InterruptsM_coverage.svh
@@ -23,7 +23,8 @@
 `define COVER_INTERRUPTSM
 
 covergroup InterruptsM_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
 
     // building blocks for the main coverpoints
     
@@ -89,9 +90,6 @@ covergroup InterruptsM_cg with function sample(ins_t ins);
     }
     wfi: coverpoint ins.current.insn {
         bins wfi = {32'b0001000_00101_00000_000_00000_1110011};
-    }
-    priv_mode_m: coverpoint ins.current.mode {
-        bins M_mode = {2'b11};
     }
     // m_ext_intr: coverpoint ins.current.m_ext_intr {
     //     bins mei = {1};

--- a/fcov/priv/InterruptsS_coverage.svh
+++ b/fcov/priv/InterruptsS_coverage.svh
@@ -23,7 +23,8 @@
 `define COVER_INTERRUPTSS
 
 covergroup InterruptsS_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
 
     // building blocks for the main coverpoints
 
@@ -272,15 +273,6 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
     }
     s_ext_intr_low: coverpoint ins.current.s_ext_intr {
         bins no_sei = {0};
-    }
-    priv_mode_m: coverpoint ins.current.mode {
-        bins M_mode = {2'b11};
-    }
-    priv_mode_s: coverpoint ins.current.mode {
-        bins S_Mode = {2'b01};
-    }
-    priv_mode_u: coverpoint ins.current.mode {
-        bins U_Mode = {2'b00};
     }
 
     // main coverpoints

--- a/fcov/priv/InterruptsSstc_coverage.svh
+++ b/fcov/priv/InterruptsSstc_coverage.svh
@@ -23,7 +23,8 @@
 `define COVER_INTERRUPTSSSTC
 
 covergroup InterruptsSstc_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
 
     // building blocks for the main coverpoints
 
@@ -71,15 +72,6 @@ covergroup InterruptsSstc_cg with function sample(ins_t ins);
     }
     read_stimecmp: coverpoint ins.current.insn[31:20] {
         bins read_stimecmp = {12'h14D};
-    }
-    priv_mode_m: coverpoint ins.current.mode {
-        bins M_mode = {2'b11};
-    }
-    priv_mode_s: coverpoint ins.current.mode {
-        bins S_Mode = {2'b01};
-    }
-    priv_mode_u: coverpoint ins.current.mode {
-        bins U_Mode = {2'b00};
     }
 
     // main coverpoints

--- a/fcov/priv/InterruptsU_coverage.svh
+++ b/fcov/priv/InterruptsU_coverage.svh
@@ -22,7 +22,8 @@
 
 `define COVER_INTERRUPTSU
 covergroup InterruptsU_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
 
     // building blocks for the main coverpoints
     mstatus_sie: coverpoint ins.current.csr[12'h300][1]  {
@@ -74,9 +75,6 @@ covergroup InterruptsU_cg with function sample(ins_t ins);
     }
     m_soft_intr: coverpoint ins.current.m_soft_intr {
         bins msi = {1};
-    }
-    priv_mode_u: coverpoint ins.current.mode {
-        bins U_mode = {2'b00};
     }
 
     // main coverpoints

--- a/fcov/priv/ZicntrM_coverage.svh
+++ b/fcov/priv/ZicntrM_coverage.svh
@@ -22,13 +22,11 @@
 
 `define COVER_ZICNTRM
 covergroup ZicntrM_mcounters_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
     // Counter access in machine mode
 
     // building blocks for the main coverpoints
-    priv_mode_m: coverpoint ins.current.mode {
-       bins M_mode = {2'b11};
-    }
     csrrw: coverpoint ins.current.insn {
         wildcard bins csrrw = {32'b????????????_?????_001_?????_1110011}; 
     }

--- a/fcov/priv/ZicntrS_coverage.svh
+++ b/fcov/priv/ZicntrS_coverage.svh
@@ -22,7 +22,8 @@
 
 `define COVER_ZICNTRS
 covergroup ZicntrS_scounters_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
     // counter access in supervisor mode
 
     // building blocks for the main coverpoints
@@ -370,15 +371,6 @@ covergroup ZicntrS_scounters_cg with function sample(ins_t ins);
         bins b_29_0 = {32'b11011111111111111111111111111111};
         bins b_30_0 = {32'b10111111111111111111111111111111};
         bins b_31_0 = {32'b01111111111111111111111111111111};
-    }
-    priv_mode_u: coverpoint ins.current.mode { 
-       bins U_mode = {2'b00};  
-    }
-    priv_mode_s: coverpoint ins.current.mode { 
-       bins S_mode = {2'b01};  
-    }
-    priv_mode_m: coverpoint ins.current.mode { 
-       bins M_mode = {2'b11};  
     }
     csrrw: coverpoint ins.current.insn {
         wildcard bins csrrw = {32'b????????????_?????_001_?????_1110011}; 

--- a/fcov/priv/ZicntrU_coverage.svh
+++ b/fcov/priv/ZicntrU_coverage.svh
@@ -22,7 +22,8 @@
 
 `define COVER_ZICNTRU
 covergroup ZicntrU_ucounters_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
     // Counter access in user mode 
 
     // building blocks for the main coverpoints
@@ -96,14 +97,6 @@ covergroup ZicntrU_ucounters_cg with function sample(ins_t ins);
         bins b_0_29  = { 32'b11011111111111111111111111111111};
         bins b_0_30  = { 32'b10111111111111111111111111111111};
         bins b_0_31  = { 32'b01111111111111111111111111111111};
-    }
-
-    priv_mode_u: coverpoint ins.current.mode{
-        bins U_Mode = {2'b00};
-    }
-
-    priv_mode_m: coverpoint ins.current.mode{
-        bins M_Mode = {2'b11};
     }
 
     csrrw: coverpoint ins.current.insn {

--- a/fcov/priv/ZicsrM_coverage.svh
+++ b/fcov/priv/ZicsrM_coverage.svh
@@ -20,7 +20,8 @@
 
 `define COVER_ZICSRM
 covergroup ZicsrM_mcsr_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
 
     // building blocks for the main coverpoints
     nonzerord: coverpoint ins.current.insn[11:7] {
@@ -62,9 +63,6 @@ covergroup ZicsrM_mcsr_cg with function sample(ins_t ins);
         ignore_bins hyper_custom3[] = {[12'hEC0:12'hEFF]};
         bins mach_std3[] = {[12'hF00:12'hFBF]};
         ignore_bins mach_custom3[] = {[12'hFC0:12'hFFF]};
-    }
-    priv_mode_m: coverpoint ins.current.mode {
-        bins M_mode = {2'b11};
     }
     rs1_ones: coverpoint ins.current.rs1_val {
         bins ones = {'1};
@@ -213,13 +211,11 @@ covergroup ZicsrM_mcsr_cg with function sample(ins_t ins);
 endgroup
 
 covergroup ZicsrM_mcause_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
- 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
+
     csrrw_mcause: coverpoint ins.current.insn {
         wildcard bins csrrw = {32'b001101000010_?????_001_?????_1110011};  // csrrw to mcause
-    }
-    priv_mode_m: coverpoint ins.current.mode {
-       bins M_mode = {2'b11};
     }
     mcause_interrupt : coverpoint ins.current.rs1_val[XLEN-1] {
         bins interrupt = {1};
@@ -279,7 +275,8 @@ endgroup
 
 
 covergroup ZicsrM_mstatus_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
 
     // SD COVERPOINTS
     // Cross-product of trying to write mstatus.SD, .FS, .XS, .VS
@@ -294,18 +291,12 @@ covergroup ZicsrM_mstatus_cg with function sample(ins_t ins);
     csrrw_mstatus: coverpoint ins.current.insn {
         wildcard bins csrrw = {32'b001100000000_?????_001_?????_1110011};  // csrrw to mstatus
     }
-    priv_mode_m: coverpoint ins.current.mode {
-       bins M_mode = {2'b11};
-    }
     cp_mstatus_sd_write: cross priv_mode_m, csrrw_mstatus, cp_mstatus_sd, cp_mstatus_fs, cp_mstatus_vs, cp_mstatus_xs;
-
-    
-
-
- endgroup
+endgroup
 
 covergroup ZicsrM_mprivinst_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
 
     privinstrs: coverpoint ins.current.insn  {
         bins ecall  = {32'h00000073};
@@ -321,13 +312,6 @@ covergroup ZicsrM_mprivinst_cg with function sample(ins_t ins);
     }
     sret: coverpoint ins.current.insn  {
         bins sret   = {32'h10200073};
-    }
-    priv_mode_m: coverpoint ins.current.mode { 
-       bins M_mode = {2'b11};
-    }    
-    // mret and sret change the privilege mode, so check the old mode it was coming from for these coverpoints used in sret/mret cross products
-    old_priv_mode_m: coverpoint ins.prev.mode { 
-       bins M_mode = {2'b11};
     }
     old_mstatus_mpp: coverpoint ins.prev.csr[12'h300][12:11] {         // *** how to handle S or U not always supported
         bins U_mode = {2'b00};
@@ -349,8 +333,8 @@ covergroup ZicsrM_mprivinst_cg with function sample(ins_t ins);
     old_mstatus_sie: coverpoint ins.prev.csr[12'h300][1] {
     }
     cp_mprivinst: cross privinstrs, priv_mode_m;
-    cp_mret: cross mret, old_priv_mode_m, old_mstatus_mpp, old_mstatus_mprv, old_mstatus_mpie, old_mstatus_mie;
-    cp_sret: cross sret, old_priv_mode_m, old_mstatus_spp, old_mstatus_mprv, old_mstatus_spie, old_mstatus_sie, old_mstatus_tsr;
+    cp_mret: cross mret, priv_mode_m, old_mstatus_mpp, old_mstatus_mprv, old_mstatus_mpie, old_mstatus_mie;
+    cp_sret: cross sret, priv_mode_m, old_mstatus_spp, old_mstatus_mprv, old_mstatus_spie, old_mstatus_sie, old_mstatus_tsr;
 endgroup
 
 function void zicsrm_sample(int hart, int issue, ins_t ins);

--- a/fcov/priv/ZicsrS_coverage.svh
+++ b/fcov/priv/ZicsrS_coverage.svh
@@ -22,7 +22,8 @@
 
 `define COVER_ZICSRS
 covergroup ZicsrS_scsr_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
 
     // building blocks for the main coverpoints
     nonzerord: coverpoint ins.current.insn[11:7] {
@@ -67,12 +68,6 @@ covergroup ZicsrS_scsr_cg with function sample(ins_t ins);
         ignore_bins hyper_custom3[] = {[12'hEC0:12'hEFF]};
         bins mach_std3[] = {[12'hF00:12'hFBF]};
         bins mach_custom3[] = {[12'hFC0:12'hFFF]};
-    }
-    old_priv_mode_s: coverpoint ins.prev.mode {
-        bins S_mode = {2'b01};
-    }
-    old_priv_mode_m: coverpoint ins.prev.mode {
-        bins M_mode = {2'b11};
     }
     rs1_ones: coverpoint ins.current.rs1_val {
         bins ones = {'1};
@@ -314,28 +309,26 @@ covergroup ZicsrS_scsr_cg with function sample(ins_t ins);
     }
 
     // main coverpoints
-    cp_csrr:         cross csrr,    csr,         old_priv_mode_s, nonzerord;             
-    cp_csrw_corners: cross csrrw,   csr, old_priv_mode_s, rs1_corners {
+    cp_csrr:         cross csrr,    csr,         priv_mode_s, nonzerord;             
+    cp_csrw_corners: cross csrrw,   csr, priv_mode_s, rs1_corners {
         ignore_bins satp = binsof(csr.satp);
     }
     
-    cp_csrcs:        cross csrop,   csr, old_priv_mode_s, rs1_ones {
+    cp_csrcs:        cross csrop,   csr, priv_mode_s, rs1_ones {
         ignore_bins satp = binsof(csr.satp);
     }
-    cp_scsrwalk:     cross csrname, csrop,       old_priv_mode_s, walking_ones;
-    cp_satp:         cross csrop,   satp,        old_priv_mode_s, satp_walking;
-    cp_shadow_m:     cross csrrw,   mcsrs,       old_priv_mode_m, rs1_corners;  // write 1s/0s to mstatus, mie, mip in m mode
-    cp_shadow_s:     cross csrrw,   scsrs,       old_priv_mode_s, rs1_corners;  // write 1s/0s to sstatus, sie, sip in s mode
+    cp_scsrwalk:     cross csrname, csrop,       priv_mode_s, walking_ones;
+    cp_satp:         cross csrop,   satp,        priv_mode_s, satp_walking;
+    cp_shadow_m:     cross csrrw,   mcsrs,       priv_mode_m, rs1_corners;  // write 1s/0s to mstatus, mie, mip in m mode
+    cp_shadow_s:     cross csrrw,   scsrs,       priv_mode_s, rs1_corners;  // write 1s/0s to sstatus, sie, sip in s mode
 endgroup
 
 covergroup ZicsrS_scause_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
  
     csrrw_scause: coverpoint ins.current.insn {
         wildcard bins csrrw = {32'b000101000010_?????_001_?????_1110011};
-    }
-    priv_mode_s: coverpoint ins.current.mode {
-       bins S_mode = {2'b01};
     }
     scause_interrupt : coverpoint ins.current.rs1_val[XLEN-1] {
         bins interrupt = {1};
@@ -394,7 +387,8 @@ endgroup
 
 
 covergroup ZicsrS_sstatus_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
 
     cp_sstatus_sd: coverpoint ins.current.rs1_val[XLEN-1]  {
     }
@@ -407,16 +401,14 @@ covergroup ZicsrS_sstatus_cg with function sample(ins_t ins);
     csrrw_sstatus: coverpoint ins.current.insn {
         wildcard bins csrrw = {32'b000100000000_?????_001_?????_1110011};  // csrrw to sstatus
     }
-    priv_mode_s: coverpoint ins.current.mode {
-       bins S_mode = {2'b01};
-    }
     // main coverpoints
     cp_mstatus_sd_write: cross priv_mode_s, csrrw_sstatus, cp_sstatus_sd, cp_sstatus_fs, cp_sstatus_vs, cp_sstatus_xs;
 
- endgroup
+endgroup
 
 covergroup ZicsrS_sprivinst_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
 
     privinstrs: coverpoint ins.current.insn  {
         bins ecall  = {32'h00000073};
@@ -432,14 +424,7 @@ covergroup ZicsrS_sprivinst_cg with function sample(ins_t ins);
     }
     sret: coverpoint ins.current.insn  {
         bins sret   = {32'h10200073};
-    }
-    priv_mode_s: coverpoint ins.current.mode { 
-       bins S_mode = {2'b01};
-    }    
-    // mret and sret change the privilege mode, so check the old mode it was coming from for these coverpoints used in sret/mret cross products
-    old_priv_mode_s: coverpoint ins.prev.mode { 
-       bins S_mode = {2'b01};
-    }
+    }   
     // old_mstatus_mprv: coverpoint ins.prev.csr[12'h300][17] {
     // }
     old_mstatus_tsr: coverpoint ins.prev.csr[12'h300][22] {
@@ -451,9 +436,9 @@ covergroup ZicsrS_sprivinst_cg with function sample(ins_t ins);
     old_sstatus_sie: coverpoint ins.prev.csr[12'h100][1] {
     }
     // main coverpoints
-    cp_mprivinst: cross privinstrs, old_priv_mode_s;
-    cp_mret:      cross mret,       old_priv_mode_s;
-    cp_sret:      cross sret,       old_priv_mode_s, old_sstatus_spp, old_sstatus_spie, old_sstatus_sie, old_mstatus_tsr;
+    cp_mprivinst: cross privinstrs, priv_mode_s;
+    cp_mret:      cross mret,       priv_mode_s;
+    cp_sret:      cross sret,       priv_mode_s, old_sstatus_spp, old_sstatus_spie, old_sstatus_sie, old_mstatus_tsr;
 endgroup
 
 function void zicsrs_sample(int hart, int issue, ins_t ins);

--- a/fcov/priv/ZicsrU_coverage.svh
+++ b/fcov/priv/ZicsrU_coverage.svh
@@ -22,7 +22,8 @@
 
 `define COVER_ZICSRU
 covergroup ZicsrU_ucsr_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
     // "ZicsrU ucsr"
 
     // building blocks for the main coverpoints
@@ -68,9 +69,6 @@ covergroup ZicsrU_ucsr_cg with function sample(ins_t ins);
         bins mach_std3[] = {[12'hF00:12'hFBF]};
         bins mach_custom3[] = {[12'hFC0:12'hFFF]};
     }
-    old_priv_mode_u: coverpoint ins.prev.mode {
-        bins U_mode = {2'b00};
-    }
     rs1_ones: coverpoint ins.current.rs1_val {
         bins ones = {'1};
     }
@@ -84,13 +82,14 @@ covergroup ZicsrU_ucsr_cg with function sample(ins_t ins);
     }
     
     // main coverpoints
-    cp_csrr:         cross csrr,  csr, old_priv_mode_u, nonzerord;
-    cp_csrw_corners: cross csrrw, csr, old_priv_mode_u, rs1_corners;
-    cp_csrcs:        cross csrop, csr, old_priv_mode_u, rs1_ones;
+    cp_csrr:         cross csrr,  csr, priv_mode_u, nonzerord;
+    cp_csrw_corners: cross csrrw, csr, priv_mode_u, rs1_corners;
+    cp_csrcs:        cross csrop, csr, priv_mode_u, rs1_ones;
 endgroup
 
 covergroup ZicsrU_uprivinst_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include "coverage/RISCV_coverage_standard_coverpoints.svh"
     // "ZicsrU uprivinst"
 
     // building blocks for the main coverpoints
@@ -109,16 +108,10 @@ covergroup ZicsrU_uprivinst_cg with function sample(ins_t ins);
     sret: coverpoint ins.current.insn  {
         bins sret   = {32'h10200073};
     }
-    priv_mode_u: coverpoint ins.current.mode {
-        bins U_mode = {2'b00};
-    }
-    old_priv_mode_u: coverpoint ins.prev.mode {
-        bins U_mode = {2'b00};
-    }
     // main coverpoints
-    cp_uprivinst:  cross privinstrs, old_priv_mode_u;
-    cp_mret:       cross mret, old_priv_mode_u; // should trap 
-    cp_sret:       cross sret, old_priv_mode_u; // should trap 
+    cp_uprivinst:  cross privinstrs, priv_mode_u;
+    cp_mret:       cross mret, priv_mode_u; // should trap 
+    cp_sret:       cross sret, priv_mode_u; // should trap 
 endgroup
 
 function void zicsru_sample(int hart, int issue, ins_t ins);

--- a/fcov/rv32_priv/RV32CBO_VM_coverage.svh
+++ b/fcov/rv32_priv/RV32CBO_VM_coverage.svh
@@ -19,7 +19,8 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 `define COVER_RV32CBO_VM
 covergroup RV32CBO_VM_exceptions_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include  "coverage/RISCV_coverage_standard_coverpoints.svh"
     //pte permission for leaf PTEs
     PTE_d_inv: coverpoint ins.current.pte_d[7:0] { //exp.1
         wildcard bins leaflvl_u_w = {8'b???1?110};

--- a/fcov/rv32_priv/RV32CBO_VM_coverage.svh
+++ b/fcov/rv32_priv/RV32CBO_VM_coverage.svh
@@ -92,10 +92,6 @@ covergroup RV32CBO_VM_exceptions_cg with function sample(ins_t ins);
     Mcause: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
         bins store_amo_page_fault = {64'd15};
     }
-    priv_mode: coverpoint ins.current.mode{
-        bins S_mode = {2'b01};
-        bins U_mode = {2'b00};
-    }
     sum_sstatus: coverpoint ins.current.csr[12'h100][18]{
         bins notset = {0};
         bins set = {1};
@@ -129,21 +125,17 @@ covergroup RV32CBO_VM_exceptions_cg with function sample(ins_t ins);
         ignore_bins ig1 = binsof(PTE_nonleaf_lvl0_d.lvl0_s);
     }
 
-    spage_nowrite_s_d: cross PTE_rw_spage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode, sum_sstatus { //exp.4 & 5
-        ignore_bins ig1 = binsof(priv_mode.U_mode);
+    spage_nowrite_s_d: cross PTE_rw_spage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_s, sum_sstatus { //exp.4 & 5
     }
 
-    spage_rwx_s_d_nowrite: cross PTE_spage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode { //exp.6
-        ignore_bins ig1 = binsof(priv_mode.S_mode);
+    spage_rwx_s_d_nowrite: cross PTE_spage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_u { //exp.6
     }
 
-    upage_smode_sumunset_nowrite_s: cross PTE_upage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode, sum_sstatus { //exp.7
-        ignore_bins ig1 = binsof(priv_mode.U_mode);
-        ignore_bins ig2 = binsof(sum_sstatus.set);
+    upage_smode_sumunset_nowrite_s: cross PTE_upage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_s, sum_sstatus { //exp.7
+        ignore_bins ig1 = binsof(sum_sstatus.set);
     }
 
-    upage_umode_nowrite_u: cross PTE_rw_upage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode { //exp.8
-        ignore_bins ig1 = binsof(priv_mode.S_mode);
+    upage_umode_nowrite_u: cross PTE_rw_upage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_u { //exp.8
     }
 
     Abit_unset_write_s: cross PTE_Abit_unset_d, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.9

--- a/fcov/rv32_priv/RV32VM_coverage.svh
+++ b/fcov/rv32_priv/RV32VM_coverage.svh
@@ -20,7 +20,8 @@
 
 `define COVER_RV32VM
 covergroup RV32VM_satp_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include  "coverage/RISCV_coverage_standard_coverpoints.svh"
     mode_supported: coverpoint ins.current.csr[12'h180][31] { //sat.2
         bins sv32   = {1'b1};
         bins bare   = {1'b0}; //bare.1
@@ -69,11 +70,6 @@ covergroup RV32VM_satp_cg with function sample(ins_t ins);
     tvm_mstatus: coverpoint ins.current.csr[12'h300][20]{
         bins zero = {0};
     }
-    priv_mode: coverpoint ins.current.mode{
-        bins S_mode = {2'b01};
-        bins U_mode = {2'b00};
-        bins M_mode = {2'b11};
-    }
     Mcause: coverpoint ins.current.csr[12'h342]{
         bins illegal_ins  = {32'd2};
         bins no_exception = {32'd0};
@@ -83,14 +79,11 @@ covergroup RV32VM_satp_cg with function sample(ins_t ins);
         wildcard bins csrrw = {32'b000110000000_?????_001_?????_1110011};
         wildcard bins csrrc = {32'b000110000000_?????_011_?????_1110011};
     }
-    access_u: cross priv_mode, Mcause, tvm_mstatus { //sat.1
-        ignore_bins ig1 = binsof(priv_mode.S_mode);
-        ignore_bins ig2 = binsof(priv_mode.M_mode);
-        ignore_bins ig3 = binsof(Mcause.no_exception);
+    access_u: cross priv_mode_u, Mcause, tvm_mstatus { //sat.1
+        ignore_bins ig1 = binsof(Mcause.no_exception);
     }
-    access_m_s: cross priv_mode, ins, Mcause, tvm_mstatus { //sat.1
-        ignore_bins ig1 = binsof(priv_mode.U_mode);
-        ignore_bins ig2 = binsof(Mcause.illegal_ins);
+    access_m_s: cross priv_mode_ms, ins, Mcause, tvm_mstatus { //sat.1
+        ignore_bins ig1 = binsof(Mcause.illegal_ins);
     }
 endgroup
 
@@ -124,17 +117,10 @@ covergroup RV32VM_sfence_cg with function sample(ins_t ins); //sf.1
 endgroup
 
 covergroup RV32VM_mstatus_mprv_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include  "coverage/RISCV_coverage_standard_coverpoints.svh"
     tvm_mstatus: coverpoint ins.current.csr[12'h300][20] {
         bins set = {1};
-    }
-    priv_mode: coverpoint ins.current.mode {
-        bins S_mode = {2'b01};
-        bins M_mode = {2'b11};
-    }
-    priv_mode_prev: coverpoint ins.prev.mode {      // previous mode is required in case of exceptions
-        bins S_mode = {2'b01};
-        bins M_mode = {2'b11};
     }
     Mcause: coverpoint ins.current.csr[12'h342] {
         bins illegal_ins = {32'd2};
@@ -145,11 +131,8 @@ covergroup RV32VM_mstatus_mprv_cg with function sample(ins_t ins);
         wildcard bins csrrc_satp = {32'b000110000000_?????_011_?????_1110011};
         wildcard bins sfence = {32'b0001001_?????_?????_000_00000_1110011};
     }
-
-    tvm_exception_s: cross tvm_mstatus, priv_mode_prev, Mcause, ins { //ms.1
-        ignore_bins ig1 = binsof(priv_mode_prev.M_mode);
+    tvm_exception_s: cross tvm_mstatus, priv_mode_s, Mcause, ins { //ms.1
     }
-
     mprv_mstatus: coverpoint ins.current.csr[12'h300][17]{
         bins set = {1};
     }
@@ -171,14 +154,11 @@ covergroup RV32VM_mstatus_mprv_cg with function sample(ins_t ins);
         bins bare   = {1'b0};
     }
 
-    mprv_load: cross mprv_mstatus, mpp_mstatus, read_acc, priv_mode, satp_mode { //ms.2
-        ignore_bins ig1 = binsof(priv_mode.S_mode);
+    mprv_load: cross mprv_mstatus, mpp_mstatus, read_acc, priv_mode_m, satp_mode { //ms.2
     }
-    mprv_store: cross mprv_mstatus, mpp_mstatus, write_acc, priv_mode, satp_mode { //ms.2
-        ignore_bins ig1 = binsof(priv_mode.S_mode);
+    mprv_store: cross mprv_mstatus, mpp_mstatus, write_acc, priv_mode_m, satp_mode { //ms.2
     }
-    mprv_ins: cross mprv_mstatus, mpp_mstatus, exec_acc , priv_mode, satp_mode { //ms.2
-        ignore_bins ig1 = binsof(priv_mode.S_mode);
+    mprv_ins: cross mprv_mstatus, mpp_mstatus, exec_acc , priv_mode_m, satp_mode { //ms.2
     }
 
     PTE_upage_i: coverpoint ins.current.pte_i[7:0] { //ms.3 & 4
@@ -208,42 +188,36 @@ covergroup RV32VM_mstatus_mprv_cg with function sample(ins_t ins);
         bins set = {1};
     }
 
-    mprv_upage_smode_sumunset_noread: cross mprv_mstatus, mpp_mstatus, read_acc, priv_mode, satp_mode, PTE_upage_d, PageType_d, Mcause_sum, sum_sstatus { //ms.3
-        ignore_bins ig1 = binsof(priv_mode.S_mode);
+    mprv_upage_smode_sumunset_noread: cross mprv_mstatus, mpp_mstatus, read_acc, priv_mode_m, satp_mode, PTE_upage_d, PageType_d, Mcause_sum, sum_sstatus { //ms.3
         ignore_bins ig2 = binsof(mpp_mstatus.U_mode);
         ignore_bins ig3 = binsof(satp_mode.bare);
         ignore_bins ig4 = binsof(Mcause_sum.ins_page_fault);
         ignore_bins ig5 = binsof(Mcause_sum.store_amo_page_fault);
         ignore_bins ig6 = binsof(sum_sstatus.set);
     }
-    mprv_upage_smode_sumunset_nowrite: cross mprv_mstatus, mpp_mstatus, write_acc, priv_mode, satp_mode, PTE_upage_d, PageType_d, Mcause_sum, sum_sstatus { //ms.3
-        ignore_bins ig1 = binsof(priv_mode.S_mode);
+    mprv_upage_smode_sumunset_nowrite: cross mprv_mstatus, mpp_mstatus, write_acc, priv_mode_m, satp_mode, PTE_upage_d, PageType_d, Mcause_sum, sum_sstatus { //ms.3
         ignore_bins ig2 = binsof(mpp_mstatus.U_mode);
         ignore_bins ig3 = binsof(satp_mode.bare);
         ignore_bins ig4 = binsof(Mcause_sum.ins_page_fault);
         ignore_bins ig5 = binsof(Mcause_sum.load_page_fault);
         ignore_bins ig6 = binsof(sum_sstatus.set);
     }
-    mprv_upage_smode_sumunset_noexec: cross mprv_mstatus, mpp_mstatus, exec_acc , priv_mode, satp_mode, sum_sstatus { //ms.3
-        ignore_bins ig1 = binsof(priv_mode.S_mode);
+    mprv_upage_smode_sumunset_noexec: cross mprv_mstatus, mpp_mstatus, exec_acc , priv_mode_m, satp_mode, sum_sstatus { //ms.3
         ignore_bins ig2 = binsof(mpp_mstatus.U_mode);
         ignore_bins ig3 = binsof(satp_mode.bare);
         ignore_bins ig4 = binsof(sum_sstatus.set);
     }
-    mprv_upage_smode_sumset_exec: cross mprv_mstatus, mpp_mstatus, exec_acc , priv_mode, satp_mode, sum_sstatus  { //ms.4
-        ignore_bins ig1 = binsof(priv_mode.S_mode);
+    mprv_upage_smode_sumset_exec: cross mprv_mstatus, mpp_mstatus, exec_acc , priv_mode_m, satp_mode, sum_sstatus  { //ms.4
         ignore_bins ig2 = binsof(mpp_mstatus.U_mode);
         ignore_bins ig3 = binsof(satp_mode.bare);
         ignore_bins ig4 = binsof(sum_sstatus.notset);
     }
-    mprv_upage_smode_sumset_read: cross mprv_mstatus, mpp_mstatus, read_acc , priv_mode, satp_mode, PTE_upage_d, PageType_d, sum_sstatus, Nopagefault  { //ms.4
-        ignore_bins ig1 = binsof(priv_mode.S_mode);
+    mprv_upage_smode_sumset_read: cross mprv_mstatus, mpp_mstatus, read_acc , priv_mode_m, satp_mode, PTE_upage_d, PageType_d, sum_sstatus, Nopagefault  { //ms.4
         ignore_bins ig2 = binsof(mpp_mstatus.U_mode);
         ignore_bins ig3 = binsof(satp_mode.bare);
         ignore_bins ig4 = binsof(sum_sstatus.notset);
     }
-    mprv_upage_smode_sumset_write: cross mprv_mstatus, mpp_mstatus, write_acc , priv_mode, satp_mode, PTE_upage_d, PageType_d, sum_sstatus, Nopagefault  { //ms.4
-        ignore_bins ig1 = binsof(priv_mode.S_mode);
+    mprv_upage_smode_sumset_write: cross mprv_mstatus, mpp_mstatus, write_acc , priv_mode_m, satp_mode, PTE_upage_d, PageType_d, sum_sstatus, Nopagefault  { //ms.4
         ignore_bins ig2 = binsof(mpp_mstatus.U_mode);
         ignore_bins ig3 = binsof(satp_mode.bare);
         ignore_bins ig4 = binsof(sum_sstatus.notset);
@@ -408,10 +382,6 @@ covergroup RV32VM_vm_permissions_cg with function sample(ins_t ins);
     Nopagefault: coverpoint  ins.current.csr[12'h143]{
         bins no_fault  = {32'd0};
     }
-    priv_mode: coverpoint ins.prev.mode{    // previous mode is required in case of exceptions
-        bins S_mode = {2'b01};
-        bins U_mode = {2'b00};
-    }
     sum_sstatus: coverpoint ins.current.csr[12'h100][18]{
         bins notset = {0};
         bins set = {1};
@@ -543,136 +513,115 @@ covergroup RV32VM_vm_permissions_cg with function sample(ins_t ins);
         ignore_bins ig4 = binsof(Mcause.load_page_fault);       
     }
 
-    spage_exec_s_i: cross PTE_x_spage_i, PageType_i, mode, exec_acc, Nopagefault, priv_mode, sum_sstatus { //pte.5 & 6 
+    spage_exec_s_i: cross PTE_x_spage_i, PageType_i, mode, exec_acc, Nopagefault, priv_mode_s, sum_sstatus { //pte.5 & 6 
         ignore_bins ig1 = binsof(PTE_x_spage_i.leaflvl_x_0);
-        ignore_bins ig2 = binsof(priv_mode.U_mode);
     }
-    spage_noexec_s_i: cross PTE_x_spage_i, PageType_i, mode, Mcause, exec_acc, priv_mode, sum_sstatus { //pte.5 & 6
+    spage_noexec_s_i: cross PTE_x_spage_i, PageType_i, mode, Mcause, exec_acc, priv_mode_s, sum_sstatus { //pte.5 & 6
         ignore_bins ig1 = binsof(PTE_x_spage_i.leaflvl_x_1);
         ignore_bins ig2 = binsof(Mcause.load_page_fault);
         ignore_bins ig3 = binsof(Mcause.store_amo_page_fault);
-        ignore_bins ig4 = binsof(priv_mode.U_mode);
     }
 
-    spage_read_s_d: cross PTE_rw_spage_d, PageType_d, mode, Nopagefault, read_acc, priv_mode, sum_sstatus { //pte.5 & 6
-        ignore_bins ig1 = binsof(priv_mode.U_mode);
-        ignore_bins ig2 = binsof(PTE_rw_spage_d.leaflvl_r_0);
-        ignore_bins ig3 = binsof(PTE_rw_spage_d.leaflvl_w_0);
-        ignore_bins ig4 = binsof(PTE_rw_spage_d.leaflvl_w_1);
+    spage_read_s_d: cross PTE_rw_spage_d, PageType_d, mode, Nopagefault, read_acc, priv_mode_s, sum_sstatus { //pte.5 & 6
+        ignore_bins ig1 = binsof(PTE_rw_spage_d.leaflvl_r_0);
+        ignore_bins ig2 = binsof(PTE_rw_spage_d.leaflvl_w_0);
+        ignore_bins ig3 = binsof(PTE_rw_spage_d.leaflvl_w_1);
     }
-    spage_noread_s_d: cross PTE_rw_spage_d, PageType_d, mode, Mcause, read_acc, priv_mode, sum_sstatus { //pte.5 & 6
-        ignore_bins ig1 = binsof(priv_mode.U_mode);
-        ignore_bins ig2 = binsof(PTE_rw_spage_d.leaflvl_r_1);
-        ignore_bins ig3 = binsof(PTE_rw_spage_d.leaflvl_w_0);
-        ignore_bins ig4 = binsof(PTE_rw_spage_d.leaflvl_w_1);
-        ignore_bins ig5 = binsof(Mcause.store_amo_page_fault);
-        ignore_bins ig6 = binsof(Mcause.ins_page_fault);
-    }
-
-    spage_write_s_d: cross PTE_rw_spage_d, PageType_d, mode, Nopagefault, write_acc, priv_mode, sum_sstatus { //pte.5 & 6
-        ignore_bins ig1 = binsof(priv_mode.U_mode);
-        ignore_bins ig2 = binsof(PTE_rw_spage_d.leaflvl_r_0);
-        ignore_bins ig3 = binsof(PTE_rw_spage_d.leaflvl_w_0);
-        ignore_bins ig4 = binsof(PTE_rw_spage_d.leaflvl_r_1);
-    }
-    spage_nowrite_s_d: cross PTE_rw_spage_d, PageType_d, mode, Mcause, write_acc, priv_mode, sum_sstatus { //pte.5 & 6
-        ignore_bins ig1 = binsof(priv_mode.U_mode);
-        ignore_bins ig2 = binsof(PTE_rw_spage_d.leaflvl_r_0);
-        ignore_bins ig3 = binsof(PTE_rw_spage_d.leaflvl_r_1);
-        ignore_bins ig4 = binsof(PTE_rw_spage_d.leaflvl_w_1);
+    spage_noread_s_d: cross PTE_rw_spage_d, PageType_d, mode, Mcause, read_acc, priv_mode_s, sum_sstatus { //pte.5 & 6
+        ignore_bins ig1 = binsof(PTE_rw_spage_d.leaflvl_r_1);
+        ignore_bins ig2 = binsof(PTE_rw_spage_d.leaflvl_w_0);
+        ignore_bins ig3 = binsof(PTE_rw_spage_d.leaflvl_w_1);
+        ignore_bins ig4 = binsof(Mcause.store_amo_page_fault);
         ignore_bins ig5 = binsof(Mcause.ins_page_fault);
-        ignore_bins ig6 = binsof(Mcause.load_page_fault);
     }
 
-    spage_rwx_s_i_noexec: cross PTE_spage_i, PageType_i, mode, Mcause, exec_acc, priv_mode { //pte.7
+    spage_write_s_d: cross PTE_rw_spage_d, PageType_d, mode, Nopagefault, write_acc, priv_mode_s, sum_sstatus { //pte.5 & 6
+        ignore_bins ig1 = binsof(PTE_rw_spage_d.leaflvl_r_0);
+        ignore_bins ig2 = binsof(PTE_rw_spage_d.leaflvl_w_0);
+        ignore_bins ig3 = binsof(PTE_rw_spage_d.leaflvl_r_1);
+    }
+    spage_nowrite_s_d: cross PTE_rw_spage_d, PageType_d, mode, Mcause, write_acc, priv_mode_s, sum_sstatus { //pte.5 & 6
+        ignore_bins ig1 = binsof(PTE_rw_spage_d.leaflvl_r_0);
+        ignore_bins ig2 = binsof(PTE_rw_spage_d.leaflvl_r_1);
+        ignore_bins ig3 = binsof(PTE_rw_spage_d.leaflvl_w_1);
+        ignore_bins ig4 = binsof(Mcause.ins_page_fault);
+        ignore_bins ig5 = binsof(Mcause.load_page_fault);
+    }
+
+    spage_rwx_s_i_noexec: cross PTE_spage_i, PageType_i, mode, Mcause, exec_acc, priv_mode_u { //pte.7
         ignore_bins ig1 = binsof(Mcause.load_page_fault);
         ignore_bins ig2 = binsof(Mcause.store_amo_page_fault);
-        ignore_bins ig3 = binsof(priv_mode.S_mode);
     }
-    spage_rwx_s_d_noread: cross PTE_spage_d, PageType_d, mode, Mcause, read_acc, priv_mode {  //pte.7
+    spage_rwx_s_d_noread: cross PTE_spage_d, PageType_d, mode, Mcause, read_acc, priv_mode_u {  //pte.7
         ignore_bins ig1 = binsof(Mcause.ins_page_fault);
         ignore_bins ig2 = binsof(Mcause.store_amo_page_fault);
-        ignore_bins ig3 = binsof(priv_mode.S_mode);
     }
-    spage_rwx_s_d_nowrite: cross PTE_spage_d, PageType_d, mode, Mcause, write_acc, priv_mode { //pte.7
+    spage_rwx_s_d_nowrite: cross PTE_spage_d, PageType_d, mode, Mcause, write_acc, priv_mode_u { //pte.7
         ignore_bins ig1 = binsof(Mcause.ins_page_fault);
         ignore_bins ig2 = binsof(Mcause.load_page_fault);
-        ignore_bins ig3 = binsof(priv_mode.S_mode);
     } 
 
-    upage_smode_sumunset_noexec_s: cross PTE_upage_i, PageType_i, mode, Mcause, exec_acc, priv_mode , sum_sstatus { //pte.8
+    upage_smode_sumunset_noexec_s: cross PTE_upage_i, PageType_i, mode, Mcause, exec_acc, priv_mode_s , sum_sstatus { //pte.8
         ignore_bins ig1 = binsof(Mcause.store_amo_page_fault);
         ignore_bins ig2 = binsof(Mcause.load_page_fault);
-        ignore_bins ig3 = binsof(priv_mode.U_mode);
-        ignore_bins ig4 = binsof(sum_sstatus.set);
+        ignore_bins ig3 = binsof(sum_sstatus.set);
     }
-    upage_smode_sumunset_noread_s: cross PTE_upage_d, PageType_d, mode, Mcause, read_acc, priv_mode , sum_sstatus { //pte.8
+    upage_smode_sumunset_noread_s: cross PTE_upage_d, PageType_d, mode, Mcause, read_acc, priv_mode_s , sum_sstatus { //pte.8
         ignore_bins ig1 = binsof(Mcause.ins_page_fault);
         ignore_bins ig2 = binsof(Mcause.store_amo_page_fault);
-        ignore_bins ig3 = binsof(priv_mode.U_mode);
-        ignore_bins ig4 = binsof(sum_sstatus.set);
+        ignore_bins ig3 = binsof(sum_sstatus.set);
     }
-    upage_smode_sumunset_nowrite_s: cross PTE_upage_d, PageType_d, mode, Mcause, write_acc, priv_mode, sum_sstatus { //pte.8
+    upage_smode_sumunset_nowrite_s: cross PTE_upage_d, PageType_d, mode, Mcause, write_acc, priv_mode_s, sum_sstatus { //pte.8
         ignore_bins ig1 = binsof(Mcause.ins_page_fault);
         ignore_bins ig2 = binsof(Mcause.load_page_fault);
-        ignore_bins ig3 = binsof(priv_mode.U_mode);
-        ignore_bins ig4 = binsof(sum_sstatus.set);
+        ignore_bins ig3 = binsof(sum_sstatus.set);
     }
     
-    upage_smode_sumset_noexec_s: cross PTE_upage_i, PageType_i, mode, Mcause, exec_acc, priv_mode , sum_sstatus { //pte.9
+    upage_smode_sumset_noexec_s: cross PTE_upage_i, PageType_i, mode, Mcause, exec_acc, priv_mode_s, sum_sstatus { //pte.9
         ignore_bins ig1 = binsof(Mcause.load_page_fault);
         ignore_bins ig2 = binsof(Mcause.store_amo_page_fault);
-        ignore_bins ig3 = binsof(priv_mode.U_mode);
-        ignore_bins ig4 = binsof(sum_sstatus.notset);
+        ignore_bins ig3 = binsof(sum_sstatus.notset);
     }
-    upage_smode_sumset_read_s: cross PTE_upage_d, PageType_d, mode, Nopagefault, read_acc, priv_mode, sum_sstatus  { //pte.9
-        ignore_bins ig1 = binsof(priv_mode.U_mode);
-        ignore_bins ig2 = binsof(sum_sstatus.notset);
+    upage_smode_sumset_read_s: cross PTE_upage_d, PageType_d, mode, Nopagefault, read_acc, priv_mode_s, sum_sstatus  { //pte.9
+        ignore_bins ig1 = binsof(sum_sstatus.notset);
     }
-    upage_smode_sumset_write_s: cross PTE_upage_d, PageType_d, mode, Nopagefault, write_acc, priv_mode, sum_sstatus { //pte.9
-        ignore_bins ig1 = binsof(priv_mode.U_mode);
-        ignore_bins ig2 = binsof(sum_sstatus.notset);
+    upage_smode_sumset_write_s: cross PTE_upage_d, PageType_d, mode, Nopagefault, write_acc, priv_mode_s, sum_sstatus { //pte.9
+        ignore_bins ig1 = binsof(sum_sstatus.notset);
     }
 
-    upage_umode_exec_u: cross PTE_x_upage_i, PageType_i, mode, Nopagefault, exec_acc, priv_mode { //pte.10
-        ignore_bins ig1 = binsof(priv_mode.S_mode);
-        ignore_bins ig2 = binsof(PTE_x_upage_i.leaflvl_x_0);
+    upage_umode_exec_u: cross PTE_x_upage_i, PageType_i, mode, Nopagefault, exec_acc, priv_mode_u { //pte.10
+        ignore_bins ig1 = binsof(PTE_x_upage_i.leaflvl_x_0);
     }
-    upage_umode_noexec_u: cross PTE_x_upage_i, PageType_i, mode, Mcause, exec_acc, priv_mode { //pte.10
+    upage_umode_noexec_u: cross PTE_x_upage_i, PageType_i, mode, Mcause, exec_acc, priv_mode_u { //pte.10
         ignore_bins ig1 =  binsof(Mcause.load_page_fault);
         ignore_bins ig2 =  binsof(Mcause.store_amo_page_fault);
-        ignore_bins ig3 = binsof(priv_mode.S_mode);
-        ignore_bins ig4 = binsof(PTE_x_upage_i.leaflvl_x_1);
+        ignore_bins ig3 = binsof(PTE_x_upage_i.leaflvl_x_1);
     }
 
-    upage_umode_read_u: cross PTE_rw_upage_d, PageType_d, mode,  Nopagefault, read_acc, priv_mode { //pte.10
+    upage_umode_read_u: cross PTE_rw_upage_d, PageType_d, mode,  Nopagefault, read_acc, priv_mode_u { //pte.10
         ignore_bins ig1 = binsof(PTE_rw_upage_d.leaflvl_r_0);
         ignore_bins ig2 = binsof(PTE_rw_upage_d.leaflvl_w_0);
         ignore_bins ig3 = binsof(PTE_rw_upage_d.leaflvl_w_1);
-        ignore_bins ig4 = binsof(priv_mode.S_mode);   
     }
-    upage_umode_noread_u: cross PTE_rw_upage_d, PageType_d, mode,  Mcause, read_acc, priv_mode { //pte.10
+    upage_umode_noread_u: cross PTE_rw_upage_d, PageType_d, mode,  Mcause, read_acc, priv_mode_u { //pte.10
         ignore_bins ig1 = binsof(Mcause.ins_page_fault);
         ignore_bins ig2 = binsof(Mcause.store_amo_page_fault);
-        ignore_bins ig3 = binsof(priv_mode.S_mode);
-        ignore_bins ig4 = binsof(PTE_rw_upage_d.leaflvl_r_1);
-        ignore_bins ig5 = binsof(PTE_rw_upage_d.leaflvl_w_0);
-        ignore_bins ig6 = binsof(PTE_rw_upage_d.leaflvl_w_1);
+        ignore_bins ig3 = binsof(PTE_rw_upage_d.leaflvl_r_1);
+        ignore_bins ig4 = binsof(PTE_rw_upage_d.leaflvl_w_0);
+        ignore_bins ig5 = binsof(PTE_rw_upage_d.leaflvl_w_1);
     }
 
-    upage_umode_write_u: cross PTE_rw_upage_d, PageType_d, mode, Nopagefault, write_acc, priv_mode { //pte.10
+    upage_umode_write_u: cross PTE_rw_upage_d, PageType_d, mode, Nopagefault, write_acc, priv_mode_u { //pte.10
         ignore_bins ig1 = binsof(PTE_rw_upage_d.leaflvl_r_0);
         ignore_bins ig2 = binsof(PTE_rw_upage_d.leaflvl_w_0);
         ignore_bins ig3 = binsof(PTE_rw_upage_d.leaflvl_r_1);
-        ignore_bins ig4 = binsof(priv_mode.S_mode);
     }
-    upage_umode_nowrite_u: cross PTE_rw_upage_d, PageType_d, mode, Mcause, write_acc, priv_mode { //pte.10
+    upage_umode_nowrite_u: cross PTE_rw_upage_d, PageType_d, mode, Mcause, write_acc, priv_mode_u { //pte.10
         ignore_bins ig1 = binsof(PTE_rw_upage_d.leaflvl_r_0);
         ignore_bins ig2 = binsof(PTE_rw_upage_d.leaflvl_r_1);
         ignore_bins ig3 = binsof(PTE_rw_upage_d.leaflvl_w_1);
         ignore_bins ig4 = binsof(Mcause.ins_page_fault);
         ignore_bins ig5 = binsof(Mcause.load_page_fault);
-        ignore_bins ig6 = binsof(priv_mode.S_mode);
     }
 
     xpage_mxrunset_read_s: cross PTE_XnoRW_d, PageType_d, mode, Mcause, read_acc, mxr_sstatus { //pte.11
@@ -865,5 +814,3 @@ function void rv32vm_sample(int hart, int issue, ins_t ins);
         RV32VM_res_global_pte_cg.sample(ins);
         RV32VM_add_feature_cg.sample(ins);
 endfunction
-
-   

--- a/fcov/rv32_priv/RV32VM_coverage.svh
+++ b/fcov/rv32_priv/RV32VM_coverage.svh
@@ -241,7 +241,8 @@ covergroup RV32VM_mstatus_mprv_cg with function sample(ins_t ins);
 endgroup
 
 covergroup RV32VM_vm_permissions_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include  "coverage/RISCV_coverage_standard_coverpoints.svh"
     //pte permission for leaf PTEs
     PTE_i_inv: coverpoint ins.current.pte_i[7:0] { //pte.2
         wildcard bins leaflvl_u = {8'b???11??0};

--- a/fcov/rv64_priv/RV64CBO_VM_coverage.svh
+++ b/fcov/rv64_priv/RV64CBO_VM_coverage.svh
@@ -19,7 +19,8 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 `define COVER_RV64CBO_VM
 covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include  "coverage/RISCV_coverage_standard_coverpoints.svh"
     //pte permission for leaf PTEs
     PTE_d_inv: coverpoint ins.current.pte_d[7:0] { //exp.1
         wildcard bins leaflvl_u_w = {8'b???1?110};

--- a/fcov/rv64_priv/RV64CBO_VM_coverage.svh
+++ b/fcov/rv64_priv/RV64CBO_VM_coverage.svh
@@ -105,10 +105,6 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
     Mcause: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
         bins store_amo_page_fault = {64'd15};
     }
-    priv_mode: coverpoint ins.current.mode{
-        bins S_mode = {2'b01};
-        bins U_mode = {2'b00};
-    }
     sum_sstatus: coverpoint ins.current.csr[12'h100][18]{
         bins notset = {0};
         bins set = {1};
@@ -152,21 +148,17 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
         `endif 
     }
 
-    spage_nowrite_s_d: cross PTE_rw_spage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode, sum_sstatus { //exp.4 & 5
-        ignore_bins ig1 = binsof(priv_mode.U_mode);
+    spage_nowrite_s_d: cross PTE_rw_spage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_s, sum_sstatus { //exp.4 & 5
     }
 
-    spage_rwx_s_d_nowrite: cross PTE_spage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode { //exp.6
-        ignore_bins ig1= binsof(priv_mode.S_mode);
+    spage_rwx_s_d_nowrite: cross PTE_spage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_u { //exp.6
     }
 
-    upage_smode_sumunset_nowrite_s: cross PTE_upage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode, sum_sstatus { //exp.7
-        ignore_bins ig1 = binsof(priv_mode.U_mode);
-        ignore_bins ig2 = binsof(sum_sstatus.set);
+    upage_smode_sumunset_nowrite_s: cross PTE_upage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_s, sum_sstatus { //exp.7
+        ignore_bins ig1 = binsof(sum_sstatus.set);
     }
 
-    upage_umode_nowrite_u: cross PTE_rw_upage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode { //exp.8
-        ignore_bins ig1 = binsof(priv_mode.S_mode);
+    upage_umode_nowrite_u: cross PTE_rw_upage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_u { //exp.8
     }
 
     Abit_unset_write_s: cross PTE_Abit_unset_d, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.9

--- a/fcov/rv64_priv/RV64VM_coverage.svh
+++ b/fcov/rv64_priv/RV64VM_coverage.svh
@@ -21,7 +21,8 @@
 `define COVER_RV64VM
 `define sv39
 covergroup RV64VM_satp_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include  "coverage/RISCV_coverage_standard_coverpoints.svh"
 
     mode_supported: coverpoint ins.current.csr[12'h180][63:60] { //sat.2
         `ifdef sv48
@@ -157,7 +158,8 @@ covergroup RV64VM_sfence_cg with function sample(ins_t ins); //sf.1
 endgroup
 
 covergroup RV64VM_mstatus_mprv_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include  "coverage/RISCV_coverage_standard_coverpoints.svh"
     tvm_mstatus: coverpoint ins.current.csr[12'h300][20] {
         bins set = {1};
     }
@@ -298,7 +300,8 @@ covergroup RV64VM_mstatus_mprv_cg with function sample(ins_t ins);
 endgroup
 
 covergroup RV64VM_vm_permissions_cg with function sample(ins_t ins);
-    option.per_instance = 0; 
+    option.per_instance = 0;
+    `include  "coverage/RISCV_coverage_standard_coverpoints.svh"
     //pte permission for leaf PTEs
     PTE_i_inv: coverpoint ins.current.pte_i[7:0] { //pte.2
         wildcard bins leaflvl_u = {8'b???11??0};


### PR DESCRIPTION
Adds a new standard coverpoint file that can be included in other coverpoints to reduce duplication of basic coverpoints. As a proof of concept this is used for priv_mode coverpoints.

All priv mode coverpoints are also switched to use prev to get the privilege mode at the end of the previous instruction.