### PR TITLE
modified makefile logic for MABI and BITWIDTH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ EXCEPTIONSZC_FLAG = $(if $(findstring /ExceptionsZc.S,  $<),c_zcb_,)
 CMPR_FLAGS = $(EXCEPTIONSZC_FLAG)$(ZCA_FLAG)$(ZCB_FLAG)$(ZCD_FLAG)$(ZCF_FLAG)
 
 # Set bitwidth and ABI based on XLEN for each test
-BITWIDTH = $(if $(findstring 64,$*),64,32)
-MABI = $(if $(findstring 32,$*),i,)lp$(BITWIDTH)
+BITWIDTH = $(if $(findstring rv64,$*),64,32)
+MABI = $(if $(findstring rv32,$*),i,)lp$(BITWIDTH)
 
 # Modify source file for priv tests to support 32-bit and 64-bit tests from the same source
 SOURCEFILE = $(subst priv/rv64/,priv/,$(subst priv/rv32/,priv/,$*)).S


### PR DESCRIPTION
With the vectors files having SEW in their file names, e.g. Vx32/Vx64, the current MABI and BITWIDTH logic causes confusion and failing makefile. Changed makefile so that the two are searching for "rv32" and "rv64" instead of simply "32" and "64."