### PR TITLE
Added sample template of vector instruction type VVVX

### DIFF
--- a/templates/coverage/sample_VVVX.txt
+++ b/templates/coverage/sample_VVVX.txt
@@ -1,0 +1,4 @@
+        "INSTR"     : begin
+            ins.add_vd(0);
+            ins.add_vs2(1);
+        end


### PR DESCRIPTION
Template for vector instruction type VVVX did not exist, added a sample template for it.
Example VVVX instruction:
vmv1r.v  vd, vs2
