### PR TITLE
update on covergroupgen to not generate Vx

### DIFF
--- a/bin/covergroupgen.py
+++ b/bin/covergroupgen.py
@@ -57,6 +57,7 @@ def readTestplans():
             if (arch == "Vx"):
                 for effew in ["8", "16", "32", "64"]:
                     testplans["Vx" + effew] = tp
+                del testplans["Vx"]
     return testplans
 
 # readCovergroupTemplates reads the covergroup templates from the templates directory


### PR DESCRIPTION
covergroupgen.py generated Vx on top of Vx8, Vx16, Vx32, Vx64. Updated so that Vx is no longer generated and prevents confusion.