### PR TITLE
Widening coverpoint templates for vd and vs2

### DIFF
--- a/templates/coverage/cp_vd_widen.txt
+++ b/templates/coverage/cp_vd_widen.txt
@@ -1,0 +1,4 @@
+    cp_vd_widen : coverpoint ins.get_vr_reg(ins.current.vd) iff (ins.trap == 0) {
+        //VD register assignment (widening instruction, excluding v31)
+        ignore_bins v31 = {v31};
+    }

--- a/templates/coverage/cp_vs2_widen.txt
+++ b/templates/coverage/cp_vs2_widen.txt
@@ -1,0 +1,4 @@
+    cp_vs2_widen : coverpoint ins.get_vr_reg(ins.current.vs2) iff (ins.trap == 0) {
+        //VS2 register assignment (widening operand, excluding v31)
+        ignore_bins v31 = {v31};
+    }


### PR DESCRIPTION
Added templates for cp_vd_widen and cp_vs2_widen to account that widened registers should exclude v31 as they are included in v30.