### PR TITLE
Modified testgen for vsext/vzext test generating and fixed covergroupgen

### DIFF
--- a/bin/covergroupgen.py
+++ b/bin/covergroupgen.py
@@ -109,7 +109,7 @@ def anyEFFEWExclusion(effew, instrs, tp):
 
 # Write the instruction if it has an x in the listed RV32 and RV64 columns.  When hasRV32/64 is false, the column must be empty
 # Thereby group instructions according to which XLEN they are in
-def writeInstrs(f, finit, k, covergroupTemplates, tp, arch, hasRV32, hasRV64, effew=None):
+def writeInstrs(f, finit, k, covergroupTemplates, tp, arch, hasRV32, hasRV64):
     for instr in k:
         cps = tp[instr]
         match32 = ("RV32" in cps) ^ (not hasRV32)
@@ -120,10 +120,6 @@ def writeInstrs(f, finit, k, covergroupTemplates, tp, arch, hasRV32, hasRV64, ef
             for cp in cps:
                 if(not (cp.startswith("sample_") or cp == "RV32" or cp == "RV64" or cp.startswith("EFFEW"))): # skip these initial columns
                     f.write(customizeTemplate(covergroupTemplates, cp, arch, instr))
-                if(effew != None):
-                    for effew in ["8", "16", "32", "64"]:
-                        if (anyEFFEWExclusion("EFFEW" + effew, k, tp) == False):
-                            f.write(customizeTemplate(covergroupTemplates, cp, arch, instr, effew))
             f.write(customizeTemplate(covergroupTemplates, "endgroup", arch, instr))
 
 def writeCovergroupSampleFunctions(f, k, covergroupTemplates, tp, arch, hasRV32, hasRV64):
@@ -164,6 +160,10 @@ def writeCovergroups(testPlans, covergroupTemplates):
                 finit.write(customizeTemplate(covergroupTemplates,"initheader", arch, ""))
                 k = list(tp.keys())
                 k.sort()
+
+                if arch.startswith("Vx"):
+                    effew = arch[2:]  # e.g. "8" from "Vx8"
+                    k = [instr for instr in k if f"EFFEW{effew}" in tp[instr]]
 
                 writeInstrs(f, finit, k, covergroupTemplates, tp, arch, True, True)
                 if (anyExclusion("RV64", k, tp)):

--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -1846,7 +1846,7 @@ def narrowWidenConflictReg(test, vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, 
 def make_vd(test, sew, vl, rng):
   for v in rng:
     [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
-    if (test in wvvins) or (test in wvxins) or (test in mv_ins):
+    if (test in wvvins) or (test in wvxins) or (test in mv_ins) or (test in vextins):
       while (v == vs2 or v == vs1):
         [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
     elif (test in narrowins):
@@ -1868,7 +1868,7 @@ def make_vd(test, sew, vl, rng):
 def make_vs2(test, sew, vl, rng):
   for v in rng:
     [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
-    if (test in wvvins) or (test in wvxins) or (test in mv_ins):
+    if (test in wvvins) or (test in wvxins) or (test in mv_ins) or (test in vextins):
       while (v == vd or vd == vs1):
         [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
     elif (test in narrowins):
@@ -2774,6 +2774,8 @@ maskins = mvvins + mvxins + mviins + mvvmins + mvxmins + mvimins
 v_mins = vvmins + vxmins + vimins
 mv_ins = mvvins + mvxins + mviins
 mv_mins = mvvmins + mvxmins + mvimins
+# extending
+vextins = ["vzext.vf2", "vzext.vf4", "vzext.vf8", "vsext.vf2", "vsext.vf4", "vsext.vf8"]
 
 global hazardLabel
 hazardLabel = 1
@@ -3070,7 +3072,6 @@ if __name__ == '__main__':
         maxreg = 31 # I uses registers x0-x31
 
       for extension in extensions:
-        print(extension)
       #for extension in ["I"]:  # temporary for faster run
         coverdefdir = f"{ARCH_VERIF}/fcov/unpriv"
         coverfiles = [extension]

--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -144,6 +144,7 @@ def writeSIGUPD_F(rd):
 def writeSIGUPD_V(vd, sew):
     global sigupd_count  # Allow modification of global variable
     sigupd_count += 1  # Increment counter on each call
+    # TO-DO: sigupd_count modify to vl, sew, lmul, etc.
     avl = 1   # Set AVL
     lines = ""
     tempReg = 6
@@ -2725,7 +2726,7 @@ vitype = ["vadd.vi", "vrsub.vi", "vmadc.vi", "vand.vi", "vor.vi", "vxor.vi", "vs
 vrvtype = ["vcpop.m", "vfirst.m", "vmv.vx"]
 
 vvvtype = ["vmsbf.m", "viota.m", "vmsif.m", "vmsof.m", "vzext.vf2", "vzext.vf4", "vzext.vf8", "vsext.vf2", "vsext.vf4", "vsext.vf8"]
-vxvtype = ["vmacc.vx", "vnmsac.vx", "vmadd.vx", "vnmsub.vx","vwmacc.vx", "vwmaccu.vx", "vwmaccsu.vx", "vwmaccus.vx"]
+vxvtype = ["vmacc.vx", "vnmsac.vx", "vmadd.vx", "vnmsub.vx", "vwmacc.vx", "vwmaccu.vx", "vwmaccsu.vx", "vwmaccus.vx"]
 vvxtype =["vmv.v.v"]
 vxxtype = ["vmv.s.x", "vmv.v.x"]
 vixtype = ["vmv.v.i"]
@@ -2766,8 +2767,8 @@ vimins = ["vadc.vim", "vmerge.vim"]
 mvvins = ["vmadc.vv", "vmsbc.vv", "vmseq.vv", "vmsne.vv", "vmslt.vv", "vmsltu.vv", "vmsle.vv", "vmsleu.vv"]
 mvxins = ["vmadc.vx", "vmsbc.vx", "vmseq.vx", "vmsne.vx", "vmslt.vx", "vmsltu.vx", "vmsle.vx", "vmsleu.vx", "vmsgt.vx", "vmsgtu.vx"]
 mviins = ["vmadc.vi", "vmseq.vi", "vmsne.vi", "vmsle.vi", "vmsleu.vi", "vmsgt.vi", "vmsgtu.vi"]
-mvvmins = ["vmadc.vvm", "vmsbc.vvm", "vmacc.vv", "vnmsac.vv", "vmadd.vv"]
-mvxmins = ["vmadc.vxm", "vmsbc.vxm", "vmacc.vx", "vnmsac.vx", "vmadd.vx"]
+mvvmins = ["vmadc.vvm", "vmsbc.vvm"]
+mvxmins = ["vmadc.vxm", "vmsbc.vxm"]
 mvimins = ["vmadc.vim"]
 mmins = ["vmand.mm", "vmnand.mm", "vmandn.mm", "vmxor.mm", "vmor.mm", "vmnor.mm", "vmorn.mm", "vmxnor.mm"]
 maskins = mvvins + mvxins + mviins + mvvmins + mvxmins + mvimins

--- a/templates/coverage/cmp_vd_vs1_nv0.txt
+++ b/templates/coverage/cmp_vd_vs1_nv0.txt
@@ -1,4 +1,4 @@
     cmp_vd_vs1_nv0 : coverpoint ins.get_vr_reg(ins.current.vd)  iff (ins.current.vd == ins.current.vs1 & ins.trap == 0 )  {
         //Compare assignments of all 32 registers, vd not v0
-        ignore_bins vd = {v0};
+        ignore_bins v0 = {v0};
     }

--- a/templates/coverage/cmp_vd_vs1_vs2_nv0.txt
+++ b/templates/coverage/cmp_vd_vs1_vs2_nv0.txt
@@ -1,4 +1,4 @@
     cmp_vd_vs1_vs2_nv0 : coverpoint ins.get_vr_reg(ins.current.vd) iff (ins.current.vd == ins.current.vs1 & ins.current.vd == ins.current.vs2 & ins.trap == 0 )  {
         //Compare assignments of all 32 registers, vd not v0
-        ignore_bins vd = {v0};
+        ignore_bins v0 = {v0};
     }

--- a/templates/coverage/cmp_vd_vs2_nv0.txt
+++ b/templates/coverage/cmp_vd_vs2_nv0.txt
@@ -1,4 +1,4 @@
     cmp_vd_vs2_nv0 : coverpoint ins.get_vr_reg(ins.current.vd)  iff (ins.current.vd == ins.current.vs2 & ins.trap == 0 )  {
         //Compare assignments of all 32 registers, vd not v0
-        ignore_bins vd = {v0};
+        ignore_bins v0 = {v0};
     }

--- a/templates/coverage/cmp_vs1_vs2_nv0.txt
+++ b/templates/coverage/cmp_vs1_vs2_nv0.txt
@@ -1,4 +1,4 @@
     cmp_vs1_vs2_nv0 : coverpoint ins.get_vr_reg(ins.current.vs1)  iff (ins.current.vs1 == ins.current.vs2 & ins.trap == 0 )  {
         //Compare assignments of all 32 registers, vs1 not v0
-        ignore_bins vd = {v0};
+        ignore_bins v0 = {v0};
     }

--- a/templates/testgen/testgen_footer_vector2.S
+++ b/templates/testgen/testgen_footer_vector2.S
@@ -8,6 +8,7 @@ rvtest_sig_begin:
 sig_begin_canary:
 CANARY;
 
+    .align 3
 signature_base:
     .fill sigupd_count*(XLEN/32),4,0xdeadbeef
 


### PR DESCRIPTION
- Fixed covergroupgen such that if an instruction is not available for certain SEWs, the correct covergroups are generated.
- Modified testgen for vsext/vzext instructions to run on easy coverpoints.

Note: this PR may have merging issues as I created the branch from the previous PR, but nothing from the previous PR should be modified