### PR TITLE
First draft for vector corner value coverpoints/tests and updating VLEN

### DIFF
--- a/bin/sail-parse.py
+++ b/bin/sail-parse.py
@@ -19,7 +19,7 @@ def sailLog2Trace(inputLogFile, outputTraceFile):
 
     # Regular expressions to match register updates
     reg_patterns = {
-        'CSR': re.compile(r'CSR .* \(0x(\d+)\) <- (0x[0-9a-fA-F]+)'),
+        'CSR': re.compile(r'CSR .* \(0x(\d+)\) (?:<-|->) (0x[0-9a-fA-F]+)'),
         'X': re.compile(r'x(\d+) <- (0x[0-9a-fA-F]+)'),
         'F': re.compile(r'f(\d+) <- (0x[0-9a-fA-F]+)'),
         'V': re.compile(r'v(\d+) <- ([0-9a-fA-F]+)'),

--- a/bin/sail-parse.py
+++ b/bin/sail-parse.py
@@ -19,7 +19,7 @@ def sailLog2Trace(inputLogFile, outputTraceFile):
 
     # Regular expressions to match register updates
     reg_patterns = {
-        'CSR': re.compile(r'CSR .* \(0x(\d+)\) (?:<-|->) (0x[0-9a-fA-F]+)'),
+        'CSR': re.compile(r'CSR .* \((0x[0-9a-fA-F]+)\) (?:<-|->) (0x[0-9a-fA-F]+)'),
         'X': re.compile(r'x(\d+) <- (0x[0-9a-fA-F]+)'),
         'F': re.compile(r'f(\d+) <- (0x[0-9a-fA-F]+)'),
         'V': re.compile(r'v(\d+) <- (0x[0-9a-fA-F]+)'),

--- a/bin/sail-parse.py
+++ b/bin/sail-parse.py
@@ -22,7 +22,7 @@ def sailLog2Trace(inputLogFile, outputTraceFile):
         'CSR': re.compile(r'CSR .* \(0x(\d+)\) (?:<-|->) (0x[0-9a-fA-F]+)'),
         'X': re.compile(r'x(\d+) <- (0x[0-9a-fA-F]+)'),
         'F': re.compile(r'f(\d+) <- (0x[0-9a-fA-F]+)'),
-        'V': re.compile(r'v(\d+) <- ([0-9a-fA-F]+)'),
+        'V': re.compile(r'v(\d+) <- (0x[0-9a-fA-F]+)'),
     }
 
     # Mode mapping

--- a/bin/sail-parse.py
+++ b/bin/sail-parse.py
@@ -22,7 +22,7 @@ def sailLog2Trace(inputLogFile, outputTraceFile):
         'CSR': re.compile(r'CSR .* \(0x(\d+)\) <- (0x[0-9a-fA-F]+)'),
         'X': re.compile(r'x(\d+) <- (0x[0-9a-fA-F]+)'),
         'F': re.compile(r'f(\d+) <- (0x[0-9a-fA-F]+)'),
-        'V': re.compile(r'v(\d+) <- (0x[0-9a-fA-F]+)'),
+        'V': re.compile(r'v(\d+) <- ([0-9a-fA-F]+)'),
     }
 
     # Mode mapping

--- a/bin/vector-testgen.py
+++ b/bin/vector-testgen.py
@@ -882,8 +882,8 @@ def genVector(sew, vl, vlen, test):
 
   maxVtests = 700
   # TODO: Fix this temporary arbitrary number
-  num_words = vlen // 32
-  # num_words = math.ceil((vl * sew) / 32)
+  # num_words = vlen // 32
+  num_words = math.ceil((vl * sew) / 32)
   for t in range(maxVtests):
       f.write(f"v_random_{t:03d}:\n")
       for i in range(num_words):
@@ -938,7 +938,9 @@ def genVsCorners(sew, vl, vlen, test, emul):
     "min":    2**(eew - 1),
     "minm1":  2**(eew - 1) + 1,
     "max":    2**(eew - 1) - 1,
-    "maxm1":  2**(eew - 1) - 2
+    "maxm1":  2**(eew - 1) - 2,
+    "walkeven": sum(1 << i for i in range(eew) if i % 2 == 0),
+    "walkodd":  sum(1 << i for i in range(eew) if i % 2 == 1)
   }
 
   for corner in v_register_corners:
@@ -1163,12 +1165,11 @@ if __name__ == '__main__':
       flen = 32
       formatstrlenFP = str(int(flen/4))
       formatstrFP = "0x{:0" + formatstrlenFP + "x}" # format as flen-bit hexadecimal number
-      corners = [0, 1, 2, 2**(xlen-1), 2**(xlen-1)+1, 2**(xlen-1)-1, 2**(xlen-1)-2, 2**xlen-1, 2**xlen-2]
       rcornersv = [0, 1, 2, 2**xlen-1, 2**xlen-2, 2**(xlen-1), 2**(xlen-1)+1, 2**(xlen-1)-1, 2**(xlen-1)-2]
       if (xlen == 32):
-        corners = corners + [0b01011011101111001000100001110010, 0b10101010101010101010101010101010, 0b01010101010101010101010101010101]
+        rcornersv = rcornersv + [0b01011011101111001000100001110010, 0b10101010101010101010101010101010, 0b01010101010101010101010101010101]
       else:
-        corners = corners + [0b0101101110111100100010000111011101100011101011101000011011110010, # random
+        rcornersv = rcornersv + [0b0101101110111100100010000111011101100011101011101000011011110010, # random
                             0b1010101010101010101010101010101010101010101010101010101010101010, # walking odd
                             0b0101010101010101010101010101010101010101010101010101010101010101, # walking even
                             0b0000000000000000000000000000000011111111111111111111111111111111, # Wmax
@@ -1176,18 +1177,14 @@ if __name__ == '__main__':
                             0b0000000000000000000000000000000100000000000000000000000000000000, # Wmaxp1
                             0b0000000000000000000000000000000100000000000000000000000000000001] # Wmaxp2
 
-        corners_sraiw = [0b0000000000000000000000000000000000000000000000000000000000000000,
-                        0b0000000000000000000000000000000000000000000000000000000000000001,
-                        0b1111111111111111111111111111111111111111111111111111111111111111,
-                        0b0000000000000000000000000000000001111111111111111111111111111111,
-                        0b1111111111111111111111111111111110000000000000000000000000000000]
 
-      vectorcorners = ["vs_corner_zero", "vs_corner_one", "vs_corner_two", "vs_corner_ones", "vs_corner_onesm1", "vs_corner_min", "vs_corner_minm1", "vs_corner_max", "vs_corner_maxm1"]
-      vcornersemul1 = [(vcorner + "_emul1") for vcorner in vectorcorners]
-      vcornersemul2 = [(vcorner + "_emul2") for vcorner in vectorcorners]
-      vcornersemulf2 = [(vcorner + "_emulf2") for vcorner in vectorcorners]
-      vcornersemulf4 = [(vcorner + "_emulf4") for vcorner in vectorcorners]
-      vcornersemulf8 = [(vcorner + "_emulf8") for vcorner in vectorcorners]
+      vectorcorners = ["vs_corner_zero", "vs_corner_one", "vs_corner_two", "vs_corner_ones", "vs_corner_onesm1", "vs_corner_min", "vs_corner_minm1",
+                       "vs_corner_max", "vs_corner_maxm1", "vs_corner_walkeven", "vs_corner_walkodd"]
+      vcornersemul1 = [(vcorner + "_emul1") for vcorner in vectorcorners] + [f"v_random_{randint(1, 700):03d}"] # TODO: change 700 to maxVtests later
+      vcornersemul2 = [(vcorner + "_emul2") for vcorner in vectorcorners] + [f"v_random_{randint(1, 700):03d}"]
+      vcornersemulf2 = [(vcorner + "_emulf2") for vcorner in vectorcorners] + [f"v_random_{randint(1, 700):03d}"]
+      vcornersemulf4 = [(vcorner + "_emulf4") for vcorner in vectorcorners] + [f"v_random_{randint(1, 700):03d}"]
+      vcornersemulf8 = [(vcorner + "_emulf8") for vcorner in vectorcorners] + [f"v_random_{randint(1, 700):03d}"]
       vcornerseew1 = [(vcorner + "_eew1") for vcorner in vectorcorners]
 
 

--- a/bin/vector-testgen.py
+++ b/bin/vector-testgen.py
@@ -498,14 +498,14 @@ def make_vs1_vs2(test, sew, vl, rng):
     writeCovVector_V(desc, v, v, vd, vs1val, vs2val, test, sew=sew, rs1=rs1, rd=rd, rs1val=rs1val, imm=immval, vta=0)
 
 
-def make_vs2_corners(test, sew, vl, rng):
+def make_vs2_corners(test, sew, vl, vcorners):
   for v in vcorners:
     [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
     desc = f"cp_vs2_corners (Test source vs2 value = " + v + ")"
     writeCovVector_V(desc, vs1, vs2, vd, vs1val, v, test, sew=sew, rs1=rs1, rd=rd, rs1val=rs1val, imm=immval, vta=0)
 
 
-def make_vs1_corners(test, sew, vl, rng):
+def make_vs1_corners(test, sew, vl, vcorners):
   for v in vcorners:
     [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
     desc = f"cp_vs1_corners (Test source vs1 value = " + v + ")"
@@ -642,15 +642,28 @@ def make_vl(test, vlen, sew, rng):
         writeCovVector_V(desc, vs1, vs2, vd, vs1val, vs2val, test, sew=sew, lmul=lmul, vl=vl, rs1=rs1, rd=rd, rs1val=rs1val, imm=immval, vta=vta)
 
 
-def make_vs2_vs1_corners(test, sew, vl):
-  for v1 in vcorners:
-    for v2 in vcorners:
+def make_vs2_vs1_corners(test, sew, vl, vs2corners, vs1corners):
+  for v1 in vs1corners:
+    for v2 in vs2corners:
       [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
       while vs1 == vs2:
         [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
-      desc = "cp_vs2_vs1_corners"
+      desc = "cr_vs2_vs1_corners"
       writeCovVector_V(desc, vs1, vs2, vd, v1, v2, test, sew, vta=0)
 
+def make_vs2_rs1_corners(test, sew, vl, vs2corners):
+  for r1 in rcornersv:
+    for v2 in vs2corners:
+      [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
+      desc = "cr_vs2_rs1_corners"
+      writeCovVector_V(desc, vs1, vs2, vd, vs1val, v2, test, sew=sew, rs1=rs1, rs1val=r1, vta=0)
+
+def make_vs2_imm_corners(test, sew, vl, vs2corners):
+  for imm in immcornersv:
+    for v2 in vs2corners:
+      [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
+      desc = "cr_vs2_imm_corners"
+      writeCovVector_V(desc, vs1, vs2, vd, vs1val, v2, test, sew=sew, imm=imm, vta=0)
 
 def make_vm(test, vlen, sew, rng):
   lmul = 1
@@ -666,9 +679,9 @@ def make_vm(test, vlen, sew, rng):
 
 
 # TODO: Check this with vector FP. Wasnt available in csv yet so couldnt check
-def make_vxrm_vs1_vs2_corners(test, vlen, sew, vl):
-  for v1 in vcorners:
-    for v2 in vcorners:
+def make_vxrm_vs1_vs2_corners(test, vlen, sew, vl, vs2corners, vs1corners):
+  for v1 in vs1corners:
+    for v2 in vs2corners:
       [vs1, vs2, rs1, vd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
       while vs1 == vs2:
         [vs1, vs2, rs1, vd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
@@ -714,8 +727,6 @@ def write_tests(coverpoints, test, xlen=None, vlen=None, sew=None, vlmax=None, v
       make_rs1_v(test, sew, vl, range(maxreg+1))
     elif (coverpoint == "cp_imm_5bit") or (coverpoint == "cp_imm_5bit_u"):
       make_imm_v(test, sew, vl)
-    elif (coverpoint == "cp_rs1_corners"):
-      make_rs1_corners_v(test, sew, vl, range(maxreg+1))
     elif (coverpoint == "cp_vd"):
       make_vd(test, sew, vl, range(maxreg+1))
     elif (coverpoint == "cp_vd_nv0"):
@@ -768,10 +779,20 @@ def write_tests(coverpoints, test, xlen=None, vlen=None, sew=None, vlmax=None, v
       make_vl(test, vlen, sew, range(1,maxreg+1))
     elif (coverpoint == "cp_vtype"):
       make_vtype(test, vlen, sew, range(1,maxreg+1))
-    elif (coverpoint == "cp_vs1_corners"):
-      make_vs1_corners(test, sew, vl, range(1,maxreg+1))
     elif (coverpoint == "cp_vs2_corners"):
-      make_vs2_corners(test, sew, vl, range(1,maxreg+1))
+      make_vs2_corners(test, sew, vl, vcornersemul1)
+    elif (coverpoint == "cp_vs1_corners"):
+      make_vs1_corners(test, sew, vl, vcornersemul1)
+    elif (coverpoint == "cp_rs1_corners"):
+      make_rs1_corners_v(test, sew, vl, range(maxreg+1))
+    elif (coverpoint == "cr_vs2_vs1_corners"):
+      make_vs2_vs1_corners(test, sew, vl, vcornersemul1, vcornersemul1)
+    elif (coverpoint == "cr_vs2_rs1_corners"):
+      make_vs2_rs1_corners(test, sew, vl, vcornersemul1)
+    elif (coverpoint == "cp_imm_corners_5bit"):
+      pass # already tested in cp_imm_5bit but needed for cr_vs2_imm_corners
+    elif (coverpoint == "cr_vs2_imm_corners"):
+      make_vs2_imm_corners(test, sew, vl, vcornersemul1)
     else:
       print("Warning: " + coverpoint + " not implemented yet for " + test)
 
@@ -835,16 +856,6 @@ def genVector(sew, vl, vlen, test):
     legallmuls.append(0.25)
   if sew >= 64:
     legallmuls.append(0.125)
-  def convert(val, bitwidth):
-        return [f"0x{(val >> (sew * i)) & 0xFFFFFFFF:08x}" for i
-                in range((bitwidth + (sew-1)) // sew)]
-
-  v_register_corners = [
-      0, 1, 2, -1, -2,
-      2**(sew - 1),
-      2**(sew - 1) + 1,
-      2**(sew - 1) - 1,
-      2**(sew - 1) - 2]
 
   cp_vtype_mask_corners = [
       1 << randint(0, maxvlen - 1),
@@ -860,12 +871,6 @@ def genVector(sew, vl, vlen, test):
       for i in range(num_words):
           randomElem = getrandbits(32)
           f.write(f"    .word 0x{randomElem:08x}\n")
-
-  for i, val in enumerate(v_register_corners):
-      val &= (1 << sew) - 1
-      f.write(f"vs_corner_{i}:\n")
-      for w in convert(val, sew):
-          f.write(f"    .word {w}\n")
 
   for i, val in enumerate(cp_vtype_mask_corners):
       f.write(f"vtype_mask_corner_{i}:\n")
@@ -890,6 +895,40 @@ def genVector(sew, vl, vlen, test):
 
   f.write("\n")
   #f.close()
+
+def genVsCorners(sew, vl, vlen, test, emul):
+  def convert(val, bitwidth):
+        return [f"0x{(val >> (eew * i)) & 0xFFFFFFFF:08x}" for i
+                in range((bitwidth + (eew-1)) // eew)]
+
+  if (emul[0] == "f"):
+    eew = sew / int(emul[1])
+    ending = "emul" + emul
+  elif (emul == "eew1"):
+    eew = 1
+    ending = "eew1"
+  else:
+    eew = sew * int(emul)
+    ending = "emul" + emul
+
+  v_register_corners = {
+    "zero":   0,
+    "one":    1,
+    "two":    2,
+    "ones":   -1,
+    "onesm1": -2,
+    "min":    2**(eew - 1),
+    "minm1":  2**(eew - 1) + 1,
+    "max":    2**(eew - 1) - 1,
+    "maxm1":  2**(eew - 1) - 2
+  }
+
+  for corner in v_register_corners:
+      val = v_register_corners[corner]
+      val &= (1 << eew) - 1
+      f.write(f"vs_corner_{corner}_{ending}:\n")
+      for w in convert(val, eew):
+          f.write(f"    .word {w}\n")
 
 #
 # main body
@@ -1124,7 +1163,15 @@ if __name__ == '__main__':
                         0b1111111111111111111111111111111111111111111111111111111111111111,
                         0b0000000000000000000000000000000001111111111111111111111111111111,
                         0b1111111111111111111111111111111110000000000000000000000000000000]
-      vcorners = ["vs_corner_0", "vs_corner_1", "vs_corner_2", "vs_corner_3", "vs_corner_4", "vs_corner_5", "vs_corner_6", "vs_corner_7"]
+
+      vectorcorners = ["vs_corner_zero", "vs_corner_one", "vs_corner_two", "vs_corner_ones", "vs_corner_onesm1", "vs_corner_min", "vs_corner_minm1", "vs_corner_max", "vs_corner_maxm1"]
+      vcornersemul1 = [(vcorner + "_emul1") for vcorner in vectorcorners]
+      vcornersemul2 = [(vcorner + "_emul2") for vcorner in vectorcorners]
+      vcornersemulf2 = [(vcorner + "_emulf2") for vcorner in vectorcorners]
+      vcornersemulf4 = [(vcorner + "_emulf4") for vcorner in vectorcorners]
+      vcornersemulf8 = [(vcorner + "_emulf8") for vcorner in vectorcorners]
+      vcornerseew1 = [(vcorner + "_eew1") for vcorner in vectorcorners]
+
 
       vtype_maskcorners = ["vtype_maskcorner_0", "vtype_maskcorner_1", "vtype_maskcorner_2", "vtype_maskcorner_3", "vtype_maskcorner_4", "vtype_maskcorner_5", "vtype_maskcorner_6", "vtype_maskcorner_7"]
 
@@ -1140,6 +1187,12 @@ if __name__ == '__main__':
       includeVData = " "
       for test in coverpoints.keys():
       # print("Generating test for ", test, " with entries: ", coverpoints[test])
+
+        if (test in imm_31):
+          immcornersv = [0, 1, 2, 14, 15, 16, 17, 30, 31]
+        else:
+          immcornersv = [0, 1, 2, 14, 15, -1, -2, -15, -16]
+
         sigupd_count = 10 # number of entries in signature - start with a margin of 10 spaces
         sigupd_countF = 0  #initialize signature update count for F tests
         signatureWords = 0 #initialize signature words
@@ -1190,6 +1243,14 @@ if __name__ == '__main__':
         write_tests(coverpoints[test], test, xlen, vlen=vlen, sew=sew)
         insertTemplate("testgen_footer_vector1.S")
         genVector(sew, vl, vlen, test)
+        genVsCorners(sew, vl, vlen, test, "1")
+        if (test in narrowins) or (test in widenins) or (test in wvsins):
+          genVsCorners(sew, vl, vlen, test, "2")
+        elif (test in vextins):
+          genVsCorners(sew, vl, vlen, test, test[-2:])
+        elif (test in mmins) or (test in vrvtype) or (test in vmlogicalins):
+          genVsCorners(sew, vl, vlen, test, "eew1")
+
 
 
         # print footer

--- a/bin/vector-testgen.py
+++ b/bin/vector-testgen.py
@@ -370,6 +370,8 @@ def narrowWidenConflictReg(test, vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, 
   elif (test in wwvins):
     while (vd == vs1 or vs1 == vs2 or vs1 == (vs2+1)):
       [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
+  else:
+    [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
   return [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval]
 
 def make_vd(test, sew, vl, rng):
@@ -501,6 +503,7 @@ def make_vs1_vs2(test, sew, vl, rng):
 def make_vs2_corners(test, sew, vl, vcorners):
   for v in vcorners:
     [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
+    [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = narrowWidenConflictReg(test, vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval)
     desc = f"cp_vs2_corners (Test source vs2 value = " + v + ")"
     writeCovVector_V(desc, vs1, vs2, vd, vs1val, v, test, sew=sew, rs1=rs1, rd=rd, rs1val=rs1val, imm=immval, vta=0)
 
@@ -508,6 +511,7 @@ def make_vs2_corners(test, sew, vl, vcorners):
 def make_vs1_corners(test, sew, vl, vcorners):
   for v in vcorners:
     [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
+    [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = narrowWidenConflictReg(test, vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval)
     desc = f"cp_vs1_corners (Test source vs1 value = " + v + ")"
     writeCovVector_V(desc, vs1, vs2, vd, v, vs2val, test, sew=sew, rs1=rs1, rd=rd, rs1val=rs1val, imm=immval, vta=0)
 
@@ -521,6 +525,7 @@ def make_rs1_v(test, sew, vl, rng):
 def make_rs1_corners_v(test, sew, vl, rng):
   for rcorner in rcornersv:
     [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
+    [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = narrowWidenConflictReg(test, vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval)
     desc = f"cp_rs1_corners (Test source rs1 value = " + hex(rcorner) + ")"
     writeCovVector_V(desc, vs1, vs2, vd, vs1val, vs2val, test, sew=sew, rs1=rs1, rd=rd, rs1val=rcorner, imm=immval, vta=0)
 
@@ -646,8 +651,9 @@ def make_vs2_vs1_corners(test, sew, vl, vs2corners, vs1corners):
   for v1 in vs1corners:
     for v2 in vs2corners:
       [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
+      [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = narrowWidenConflictReg(test, vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval)
       while vs1 == vs2:
-        [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
+        [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = narrowWidenConflictReg(test, vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval)
       desc = "cr_vs2_vs1_corners"
       writeCovVector_V(desc, vs1, vs2, vd, v1, v2, test, sew, vta=0)
 
@@ -655,6 +661,7 @@ def make_vs2_rs1_corners(test, sew, vl, vs2corners):
   for r1 in rcornersv:
     for v2 in vs2corners:
       [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
+      [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = narrowWidenConflictReg(test, vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval)
       desc = "cr_vs2_rs1_corners"
       writeCovVector_V(desc, vs1, vs2, vd, vs1val, v2, test, sew=sew, rs1=rs1, rs1val=r1, vta=0)
 
@@ -662,6 +669,7 @@ def make_vs2_imm_corners(test, sew, vl, vs2corners):
   for imm in immcornersv:
     for v2 in vs2corners:
       [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = randomizeVectorV(test)
+      [vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval] = narrowWidenConflictReg(test, vs1, vs2, rs1, vd, rd, vs1val, vs2val, rs1val, immval, vdval)
       desc = "cr_vs2_imm_corners"
       writeCovVector_V(desc, vs1, vs2, vd, vs1val, v2, test, sew=sew, imm=imm, vta=0)
 
@@ -781,18 +789,28 @@ def write_tests(coverpoints, test, xlen=None, vlen=None, sew=None, vlmax=None, v
       make_vtype(test, vlen, sew, range(1,maxreg+1))
     elif (coverpoint == "cp_vs2_corners"):
       make_vs2_corners(test, sew, vl, vcornersemul1)
+    elif (coverpoint == "cp_vs2_corners_emul2"):
+      make_vs2_corners(test, sew, vl, vcornersemul2)
     elif (coverpoint == "cp_vs1_corners"):
       make_vs1_corners(test, sew, vl, vcornersemul1)
+    elif (coverpoint == "cp_vs1_corners_emul2"):
+      make_vs1_corners(test, sew, vl, vcornersemul2)
     elif (coverpoint == "cp_rs1_corners"):
       make_rs1_corners_v(test, sew, vl, range(maxreg+1))
     elif (coverpoint == "cr_vs2_vs1_corners"):
       make_vs2_vs1_corners(test, sew, vl, vcornersemul1, vcornersemul1)
+    elif (coverpoint == "cr_vs2_vs1_corners_wv"):
+      make_vs2_vs1_corners(test, sew, vl, vcornersemul2, vcornersemul1)
     elif (coverpoint == "cr_vs2_rs1_corners"):
       make_vs2_rs1_corners(test, sew, vl, vcornersemul1)
+    elif (coverpoint == "cr_vs2_rs1_corners_wx"):
+      make_vs2_rs1_corners(test, sew, vl, vcornersemul2)
     elif (coverpoint == "cp_imm_corners_5bit"):
       pass # already tested in cp_imm_5bit but needed for cr_vs2_imm_corners
     elif (coverpoint == "cr_vs2_imm_corners"):
       make_vs2_imm_corners(test, sew, vl, vcornersemul1)
+    elif (coverpoint == "cr_vs2_imm_corners_wi"):
+      make_vs2_imm_corners(test, sew, vl, vcornersemul2)
     else:
       print("Warning: " + coverpoint + " not implemented yet for " + test)
 

--- a/fcov/RISCV_coverage.svh
+++ b/fcov/RISCV_coverage.svh
@@ -28,7 +28,7 @@ class coverage #(
   parameter int ILEN   = 32,  // Instruction length in bits
   parameter int XLEN   = 32,  // GPR length in bits
   parameter int FLEN   = 32,  // FPR length in bits
-  parameter int VLEN   = 256, // Vector register size in bits
+  parameter int VLEN   = 512, // Vector register size in bits
   parameter int NHART  = 1,   // Number of harts reported
   parameter int RETIRE = 1    // Number of instructions that can retire during valid event
 ) extends RISCV_coverage #(ILEN, XLEN, FLEN, VLEN, NHART, RETIRE);

--- a/fcov/coverage/RISCV_coverage_base.svh
+++ b/fcov/coverage/RISCV_coverage_base.svh
@@ -28,7 +28,7 @@ class RISCV_coverage
   parameter int ILEN   = 32,  // Instruction length in bits
   parameter int XLEN   = 32,  // GPR length in bits
   parameter int FLEN   = 32,  // FPR length in bits
-  parameter int VLEN   = 256, // Vector register size in bits
+  parameter int VLEN   = 512, // Vector register size in bits
   parameter int NHART  = 1,   // Number of harts reported
   parameter int RETIRE = 1    // Number of instructions that can retire during valid event
 );

--- a/fcov/coverage/RISCV_coverage_common.svh
+++ b/fcov/coverage/RISCV_coverage_common.svh
@@ -45,6 +45,9 @@
 `else
   `define FLEN 32
 `endif
+`ifdef VLEN512
+  `define VLEN 512
+`endif
 
 
 // Set register type length
@@ -52,6 +55,8 @@
 `define SIGNED_XLEN_BITS  bit signed [`XLEN-1:0]
 `define FLEN_BITS         bit        [`FLEN-1:0]
 `define SIGNED_FLEN_BITS  bit signed [`FLEN-1:0]
+`define VLEN_BITS         bit        [`VLEN-1:0]
+`define SIGNED_VLEN_BITS  bit signed [`VLEN-1:0]
 
 // Instruction operand data structure
 typedef struct {

--- a/fcov/coverage/RISCV_coverage_vector.svh
+++ b/fcov/coverage/RISCV_coverage_vector.svh
@@ -108,77 +108,76 @@ function corner_vs_values_t vs_corners_check(int hart, int issue, `VLEN_BITS val
 endfunction
 
 function corner_vs_values_t vs_corners_check_eew_1(`VLEN_BITS val);
-    casez (val)
-      {{(`VLEN-1){1'b?}}, {1'b0}}:  return zero;
-      {{(`VLEN-1){1'b?}}, {1'b1}}:  return one;
-      default:                      return random;
-    endcase
+  casez (val)
+    {{(`VLEN-1){1'b?}}, {1'b1}}:  return one;
+    default:                      return zero;
+  endcase
 endfunction
 
 function corner_vs_values_t vs_corners_check_eew_8(`VLEN_BITS val);
-    casez (val)
-      {{(`VLEN-8){1'b?}},         {(8){1'b0}}}:            return zero;
-      {{(`VLEN-8){1'b?}},         {(8-1){1'b0}}, {1'b1}}:  return one;
-      {{(`VLEN-8){1'b?}},         {(8-2){1'b0}}, {2'b10}}: return two;
-      {{(`VLEN-8){1'b?}}, {1'b1}, {(8-1){1'b0}}}:          return min;
-      {{(`VLEN-8){1'b?}}, {1'b1}, {(8-2){1'b0}}, {1'b1}}:  return minp1;
-      {{(`VLEN-8){1'b?}}, {1'b0}, {(8-1){1'b1}}}        :  return max;
-      {{(`VLEN-8){1'b?}}, {1'b0}, {(8-2){1'b1}}, {1'b0}}:  return maxm1;
-      {{(`VLEN-8){1'b?}},         {(8){1'b1}}}:            return ones;
-      {{(`VLEN-8){1'b?}},         {(8-1){1'b1}}, {1'b0}}:  return onesm1;
-      {{(`VLEN-8){1'b?}},         {(8/2){2'b10}}}:         return walkeodd;
-      {{(`VLEN-8){1'b?}},         {(8/2){2'b01}}}:         return walkeven;
-      default:                                             return random;
-    endcase
+  casez (val)
+    {{(`VLEN-8){1'b?}},         {(8){1'b0}}}:            return zero;
+    {{(`VLEN-8){1'b?}},         {(8-1){1'b0}}, {1'b1}}:  return one;
+    {{(`VLEN-8){1'b?}},         {(8-2){1'b0}}, {2'b10}}: return two;
+    {{(`VLEN-8){1'b?}}, {1'b1}, {(8-1){1'b0}}}:          return min;
+    {{(`VLEN-8){1'b?}}, {1'b1}, {(8-2){1'b0}}, {1'b1}}:  return minp1;
+    {{(`VLEN-8){1'b?}}, {1'b0}, {(8-1){1'b1}}}        :  return max;
+    {{(`VLEN-8){1'b?}}, {1'b0}, {(8-2){1'b1}}, {1'b0}}:  return maxm1;
+    {{(`VLEN-8){1'b?}},         {(8){1'b1}}}:            return ones;
+    {{(`VLEN-8){1'b?}},         {(8-1){1'b1}}, {1'b0}}:  return onesm1;
+    {{(`VLEN-8){1'b?}},         {(8/2){2'b10}}}:         return walkeodd;
+    {{(`VLEN-8){1'b?}},         {(8/2){2'b01}}}:         return walkeven;
+    default:                                             return random;
+  endcase
 endfunction
 
 function corner_vs_values_t vs_corners_check_eew_16(`VLEN_BITS val);
-    casez (val)
-      {{(`VLEN-16){1'b?}},         {(16){1'b0}}}:            return zero;
-      {{(`VLEN-16){1'b?}},         {(16-1){1'b0}}, {1'b1}}:  return one;
-      {{(`VLEN-16){1'b?}},         {(16-2){1'b0}}, {2'b10}}: return two;
-      {{(`VLEN-16){1'b?}}, {1'b1}, {(16-1){1'b0}}}:          return min;
-      {{(`VLEN-16){1'b?}}, {1'b1}, {(16-2){1'b0}}, {1'b1}}:  return minp1;
-      {{(`VLEN-16){1'b?}}, {1'b0}, {(16-1){1'b1}}}        :  return max;
-      {{(`VLEN-16){1'b?}}, {1'b0}, {(16-2){1'b1}}, {1'b0}}:  return maxm1;
-      {{(`VLEN-16){1'b?}},         {(16){1'b1}}}:            return ones;
-      {{(`VLEN-16){1'b?}},         {(16-1){1'b1}}, {1'b0}}:  return onesm1;
-      {{(`VLEN-16){1'b?}},         {(16/2){2'b10}}}:         return walkeodd;
-      {{(`VLEN-16){1'b?}},         {(16/2){2'b01}}}:         return walkeven;
-      default:                                             return random;
-    endcase
+  casez (val)
+    {{(`VLEN-16){1'b?}},         {(16){1'b0}}}:            return zero;
+    {{(`VLEN-16){1'b?}},         {(16-1){1'b0}}, {1'b1}}:  return one;
+    {{(`VLEN-16){1'b?}},         {(16-2){1'b0}}, {2'b10}}: return two;
+    {{(`VLEN-16){1'b?}}, {1'b1}, {(16-1){1'b0}}}:          return min;
+    {{(`VLEN-16){1'b?}}, {1'b1}, {(16-2){1'b0}}, {1'b1}}:  return minp1;
+    {{(`VLEN-16){1'b?}}, {1'b0}, {(16-1){1'b1}}}        :  return max;
+    {{(`VLEN-16){1'b?}}, {1'b0}, {(16-2){1'b1}}, {1'b0}}:  return maxm1;
+    {{(`VLEN-16){1'b?}},         {(16){1'b1}}}:            return ones;
+    {{(`VLEN-16){1'b?}},         {(16-1){1'b1}}, {1'b0}}:  return onesm1;
+    {{(`VLEN-16){1'b?}},         {(16/2){2'b10}}}:         return walkeodd;
+    {{(`VLEN-16){1'b?}},         {(16/2){2'b01}}}:         return walkeven;
+    default:                                               return random;
+  endcase
 endfunction
 
 function corner_vs_values_t vs_corners_check_eew_32(`VLEN_BITS val);
-    casez (val)
-      {{(`VLEN-32){1'b?}},         {(32){1'b0}}}:            return zero;
-      {{(`VLEN-32){1'b?}},         {(32-1){1'b0}}, {1'b1}}:  return one;
-      {{(`VLEN-32){1'b?}},         {(32-2){1'b0}}, {2'b10}}: return two;
-      {{(`VLEN-32){1'b?}}, {1'b1}, {(32-1){1'b0}}}:          return min;
-      {{(`VLEN-32){1'b?}}, {1'b1}, {(32-2){1'b0}}, {1'b1}}:  return minp1;
-      {{(`VLEN-32){1'b?}}, {1'b0}, {(32-1){1'b1}}}        :  return max;
-      {{(`VLEN-32){1'b?}}, {1'b0}, {(32-2){1'b1}}, {1'b0}}:  return maxm1;
-      {{(`VLEN-32){1'b?}},         {(32){1'b1}}}:            return ones;
-      {{(`VLEN-32){1'b?}},         {(32-1){1'b1}}, {1'b0}}:  return onesm1;
-      {{(`VLEN-32){1'b?}},         {(32/2){2'b10}}}:         return walkeodd;
-      {{(`VLEN-32){1'b?}},         {(32/2){2'b01}}}:         return walkeven;
-      default:                                             return random;
-    endcase
+  casez (val)
+    {{(`VLEN-32){1'b?}},         {(32){1'b0}}}:            return zero;
+    {{(`VLEN-32){1'b?}},         {(32-1){1'b0}}, {1'b1}}:  return one;
+    {{(`VLEN-32){1'b?}},         {(32-2){1'b0}}, {2'b10}}: return two;
+    {{(`VLEN-32){1'b?}}, {1'b1}, {(32-1){1'b0}}}:          return min;
+    {{(`VLEN-32){1'b?}}, {1'b1}, {(32-2){1'b0}}, {1'b1}}:  return minp1;
+    {{(`VLEN-32){1'b?}}, {1'b0}, {(32-1){1'b1}}}        :  return max;
+    {{(`VLEN-32){1'b?}}, {1'b0}, {(32-2){1'b1}}, {1'b0}}:  return maxm1;
+    {{(`VLEN-32){1'b?}},         {(32){1'b1}}}:            return ones;
+    {{(`VLEN-32){1'b?}},         {(32-1){1'b1}}, {1'b0}}:  return onesm1;
+    {{(`VLEN-32){1'b?}},         {(32/2){2'b10}}}:         return walkeodd;
+    {{(`VLEN-32){1'b?}},         {(32/2){2'b01}}}:         return walkeven;
+    default:                                               return random;
+  endcase
 endfunction
 
 function corner_vs_values_t vs_corners_check_eew_64(`VLEN_BITS val);
-    casez (val)
-      {{(`VLEN-64){1'b?}},         {(64){1'b0}}}:            return zero;
-      {{(`VLEN-64){1'b?}},         {(64-1){1'b0}}, {1'b1}}:  return one;
-      {{(`VLEN-64){1'b?}},         {(64-2){1'b0}}, {2'b10}}: return two;
-      {{(`VLEN-64){1'b?}}, {1'b1}, {(64-1){1'b0}}}:          return min;
-      {{(`VLEN-64){1'b?}}, {1'b1}, {(64-2){1'b0}}, {1'b1}}:  return minp1;
-      {{(`VLEN-64){1'b?}}, {1'b0}, {(64-1){1'b1}}}        :  return max;
-      {{(`VLEN-64){1'b?}}, {1'b0}, {(64-2){1'b1}}, {1'b0}}:  return maxm1;
-      {{(`VLEN-64){1'b?}},         {(64){1'b1}}}:            return ones;
-      {{(`VLEN-64){1'b?}},         {(64-1){1'b1}}, {1'b0}}:  return onesm1;
-      {{(`VLEN-64){1'b?}},         {(64/2){2'b10}}}:         return walkeodd;
-      {{(`VLEN-64){1'b?}},         {(64/2){2'b01}}}:         return walkeven;
-      default:                                             return random;
-    endcase
+  casez (val)
+    {{(`VLEN-64){1'b?}},         {(64){1'b0}}}:            return zero;
+    {{(`VLEN-64){1'b?}},         {(64-1){1'b0}}, {1'b1}}:  return one;
+    {{(`VLEN-64){1'b?}},         {(64-2){1'b0}}, {2'b10}}: return two;
+    {{(`VLEN-64){1'b?}}, {1'b1}, {(64-1){1'b0}}}:          return min;
+    {{(`VLEN-64){1'b?}}, {1'b1}, {(64-2){1'b0}}, {1'b1}}:  return minp1;
+    {{(`VLEN-64){1'b?}}, {1'b0}, {(64-1){1'b1}}}        :  return max;
+    {{(`VLEN-64){1'b?}}, {1'b0}, {(64-2){1'b1}}, {1'b0}}:  return maxm1;
+    {{(`VLEN-64){1'b?}},         {(64){1'b1}}}:            return ones;
+    {{(`VLEN-64){1'b?}},         {(64-1){1'b1}}, {1'b0}}:  return onesm1;
+    {{(`VLEN-64){1'b?}},         {(64/2){2'b10}}}:         return walkeodd;
+    {{(`VLEN-64){1'b?}},         {(64/2){2'b01}}}:         return walkeven;
+    default:                                               return random;
+  endcase
 endfunction

--- a/fcov/coverage/RISCV_instruction_base.svh
+++ b/fcov/coverage/RISCV_instruction_base.svh
@@ -25,7 +25,7 @@ class RISCV_instruction
   parameter int ILEN   = 32,  // Instruction length in bits
   parameter int XLEN   = 32,  // GPR length in bits
   parameter int FLEN   = 32,  // FPR length in bits
-  parameter int VLEN   = 256, // Vector register size in bits
+  parameter int VLEN   = 512, // Vector register size in bits
   parameter int NHART  = 1,   // Number of harts reported
   parameter int RETIRE = 1    // Number of instructions that can retire during valid event
 );
@@ -160,9 +160,7 @@ class RISCV_instruction
   endfunction
 
   // Lookup vector register value
-
-  //TODO bad "bit [VLEN-1:0]"
-  function bit [VLEN-1:0] get_vr_val(int hart, int issue, string key, int prev);
+  function `SIGNED_VLEN_BITS get_vr_val(int hart, int issue, string key, int prev);
     int idx = get_vr_num(key);
     if (idx >= 0) begin
       return traceDataQ[hart][issue][prev].v_wdata[idx];

--- a/fcov/coverage/RISCV_trace_data.svh
+++ b/fcov/coverage/RISCV_trace_data.svh
@@ -25,7 +25,7 @@ class riscvTraceData
   parameter int ILEN   = 32,  // Instruction length in bits
   parameter int XLEN   = 32,  // GPR length in bits
   parameter int FLEN   = 32,  // FPR length in bits
-  parameter int VLEN   = 256  // Vector register size in bits
+  parameter int VLEN   = 512  // Vector register size in bits
 );
   `ifdef COVER_E
     localparam NUM_REGS = 16;

--- a/fcov/disassemble.svh
+++ b/fcov/disassemble.svh
@@ -701,7 +701,7 @@ function string disassemble (logic [31:0] instrRaw);
     VMAXU_VX:     $sformat(decoded, "vmaxu.vx %s, %s, %s%s",      vd, vs2, rs1, vm);
 
     VMUL_VV:      $sformat(decoded, "vmul.vv %s, %s, %s%s",       vd, vs2, vs1, vm);
-    VMUL_VX:      $sformat(decoded, "vmul.vv %s, %s, %s%s",       vd, vs2, rs1, vm);
+    VMUL_VX:      $sformat(decoded, "vmul.vx %s, %s, %s%s",       vd, vs2, rs1, vm);
     VMULH_VV:     $sformat(decoded, "vmulh.vv %s, %s, %s%s",      vd, vs2, vs1, vm);
     VMULH_VX:     $sformat(decoded, "vmulh.vx %s, %s, %s%s",      vd, vs2, rs1, vm);
     VMULHU_VV:    $sformat(decoded, "vmulhu.vv %s, %s, %s%s",     vd, vs2, vs1, vm);

--- a/fcov/rvviTrace.sv
+++ b/fcov/rvviTrace.sv
@@ -33,7 +33,7 @@ interface dm
   parameter int ILEN   = 32,  // Instruction length in bits
   parameter int XLEN   = 32,  // GPR length in bits
   parameter int FLEN   = 32,  // FPR length in bits
-  parameter int VLEN   = 256, // Vector register size in bits
+  parameter int VLEN   = 512, // Vector register size in bits
   parameter int NHART  = 1,   // Number of harts reported
   parameter int RETIRE = 1    // Number of instructions that can retire during valid event
 );
@@ -55,7 +55,7 @@ interface rvviTrace
   parameter int ILEN   = 32,  // Instruction length in bits
   parameter int XLEN   = 32,  // GPR length in bits
   parameter int FLEN   = 32,  // FPR length in bits
-  parameter int VLEN   = 256, // Vector register size in bits
+  parameter int VLEN   = 512, // Vector register size in bits
   parameter int NHART  = 1,   // Number of harts reported
   parameter int RETIRE = 1    // Number of instructions that can retire during valid event
 );

--- a/fcov/testbench.sv
+++ b/fcov/testbench.sv
@@ -37,7 +37,7 @@ module testbench;
   localparam FLEN = 32;
 `endif
 
-  localparam VLEN = 256; // TODO: Make configurable (maybe just use the macro directly)
+  localparam VLEN = 512; // TODO: Make configurable (maybe just use the macro directly)
 
   localparam PA_BITS = (XLEN==32 ? 32'd34 : 32'd56);
   localparam PPN_BITS = (XLEN==32 ? 32'd22 : 32'd44);
@@ -182,7 +182,7 @@ module testbench;
           end
           "CSR": begin
             num = $sscanf(val, "%h", regNum);
-            $display("CSR: %h", regNum);
+            // $display("CSR: %h", regNum);
             val = words.pop_front();
             num = $sscanf(val, "%h", regVal);
             csr[regNum] = regVal;

--- a/fcov/testbench.sv
+++ b/fcov/testbench.sv
@@ -184,7 +184,6 @@ module testbench;
           end
           "CSR": begin
             num = $sscanf(val, "%h", regNum);
-            // $display("CSR: %h", regNum);
             val = words.pop_front();
             num = $sscanf(val, "%h", xRegVal);
             csr[regNum] = xRegVal;

--- a/fcov/testbench.sv
+++ b/fcov/testbench.sv
@@ -50,7 +50,9 @@ module testbench;
   string  words[$];
   int     order;
   int     regNum;
-  logic [(XLEN-1):0] regVal;
+  logic [(XLEN-1):0] xRegVal;
+  logic [(FLEN-1):0] fRegVal;
+  logic [(VLEN-1):0] vRegVal;
 
   // RVVI Trace interface signals
   // Basic signals
@@ -162,30 +164,30 @@ module testbench;
           "X": begin
             num = $sscanf(val, "%d", regNum);
             val = words.pop_front();
-            num = $sscanf(val, "%h", regVal);
-            x_wdata[regNum] = regVal;
+            num = $sscanf(val, "%h", xRegVal);
+            x_wdata[regNum] = xRegVal;
             x_wb |= (1 << regNum);
           end
           "F": begin
             num = $sscanf(val, "%d", regNum);
             val = words.pop_front();
-            num = $sscanf(val, "%h", regVal);
-            f_wdata[regNum] = regVal;
+            num = $sscanf(val, "%h", fRegVal);
+            f_wdata[regNum] = fRegVal;
             f_wb |= (1 << regNum);
           end
           "V": begin
             num = $sscanf(val, "%d", regNum);
             val = words.pop_front();
-            num = $sscanf(val, "%h", regVal);
-            v_wdata[regNum] = regVal;
+            num = $sscanf(val, "%h", vRegVal);
+            v_wdata[regNum] = vRegVal;
             v_wb |= (1 << regNum);
           end
           "CSR": begin
             num = $sscanf(val, "%h", regNum);
             // $display("CSR: %h", regNum);
             val = words.pop_front();
-            num = $sscanf(val, "%h", regVal);
-            csr[regNum] = regVal;
+            num = $sscanf(val, "%h", xRegVal);
+            csr[regNum] = xRegVal;
             csr_wb |= (1 << regNum);
           end
           default: begin

--- a/templates/coverage/covergroup_sample_end_vector.txt
+++ b/templates/coverage/covergroup_sample_end_vector.txt
@@ -1,0 +1,3 @@
+        endcase
+    end
+endfunction

--- a/templates/coverage/covergroup_sample_header_vector.txt
+++ b/templates/coverage/covergroup_sample_header_vector.txt
@@ -1,0 +1,4 @@
+function void ARCH_sample(int hart, int issue, ins_t ins);
+
+    if (get_csr_val(hart, issue, `SAMPLE_BEFORE, "vtype", "vsew") == EFFEW) begin
+        case (traceDataQ[hart][issue][0].inst_name)

--- a/templates/coverage/covergroup_sample_vector.txt
+++ b/templates/coverage/covergroup_sample_vector.txt
@@ -1,0 +1,3 @@
+            "INSTR"     : begin
+                ARCHCASE_INSTRNODOT_cg.sample(ins);
+            end

--- a/templates/coverage/cp_vs1_corners.txt
+++ b/templates/coverage/cp_vs1_corners.txt
@@ -1,0 +1,3 @@
+    cp_vs1_corners : coverpoint vs_corners_check(ins.hart, ins.issue, ins.current.vs1_val, "1")  iff (ins.trap == 0 )  {
+        // Corners values of vs1, assuming vl = 1
+    }

--- a/templates/coverage/cp_vs1_corners_eew1.txt
+++ b/templates/coverage/cp_vs1_corners_eew1.txt
@@ -1,0 +1,13 @@
+    cp_vs1_corners_eew1 : coverpoint vs_corners_check(ins.hart, ins.issue, ins.current.vs1_val, "m")  iff (ins.trap == 0 )  {
+        // Corners values of vs1 (eew = 1), assuming vl = 1
+        ignore_bins two = {two};
+        ignore_bins min = {min};
+        ignore_bins minp1 = {minp1};
+        ignore_bins max = {max};
+        ignore_bins maxm1 = {maxm1};
+        ignore_bins ones = {ones};
+        ignore_bins onesm1 = {onesm1};
+        ignore_bins walkeodd = {walkeodd};
+        ignore_bins walkeven = {walkeven};
+        ignore_bins random = {random};
+    }

--- a/templates/coverage/cp_vs1_corners_emul2.txt
+++ b/templates/coverage/cp_vs1_corners_emul2.txt
@@ -1,0 +1,3 @@
+    cp_vs1_corners_emul2 : coverpoint vs_corners_check(ins.hart, ins.issue, ins.current.vs1_val, "2")  iff (ins.trap == 0 )  {
+        // Corners values of vs1 (emul = 2), assuming vl = 1
+    }

--- a/templates/coverage/cp_vs2_corners.txt
+++ b/templates/coverage/cp_vs2_corners.txt
@@ -1,0 +1,3 @@
+    cp_vs2_corners : coverpoint vs_corners_check(ins.hart, ins.issue, ins.current.vs2_val, "1")  iff (ins.trap == 0 )  {
+        // Corners values of vs2, assuming vl = 1
+    }

--- a/templates/coverage/cp_vs2_corners_eew1.txt
+++ b/templates/coverage/cp_vs2_corners_eew1.txt
@@ -1,0 +1,13 @@
+    cp_vs2_corners_eew1 : coverpoint vs_corners_check(ins.hart, ins.issue, ins.current.vs2_val, "m")  iff (ins.trap == 0 )  {
+        // Corners values of vs2 (eew = 1), assuming vl = 1
+        ignore_bins two = {two};
+        ignore_bins min = {min};
+        ignore_bins minp1 = {minp1};
+        ignore_bins max = {max};
+        ignore_bins maxm1 = {maxm1};
+        ignore_bins ones = {ones};
+        ignore_bins onesm1 = {onesm1};
+        ignore_bins walkeodd = {walkeodd};
+        ignore_bins walkeven = {walkeven};
+        ignore_bins random = {random};
+    }

--- a/templates/coverage/cp_vs2_corners_emul2.txt
+++ b/templates/coverage/cp_vs2_corners_emul2.txt
@@ -1,0 +1,3 @@
+    cp_vs2_corners_emul2 : coverpoint vs_corners_check(ins.hart, ins.issue, ins.current.vs2_val, "2")  iff (ins.trap == 0 )  {
+        // Corners values of vs2 (emul = 2), assuming vl = 1
+    }

--- a/templates/coverage/cp_vs2_corners_emulf2.txt
+++ b/templates/coverage/cp_vs2_corners_emulf2.txt
@@ -1,0 +1,3 @@
+    cp_vs2_corners_emulf2 : coverpoint vs_corners_check(ins.hart, ins.issue, ins.current.vs2_val, "f2")  iff (ins.trap == 0 )  {
+        // Corners values of vs2 (emul = f2), assuming vl = 1
+    }

--- a/templates/coverage/cp_vs2_corners_emulf4.txt
+++ b/templates/coverage/cp_vs2_corners_emulf4.txt
@@ -1,0 +1,3 @@
+    cp_vs2_corners_emulf4 : coverpoint vs_corners_check(ins.hart, ins.issue, ins.current.vs2_val, "f4")  iff (ins.trap == 0 )  {
+        // Corners values of vs2 (emul = f4), assuming vl = 1
+    }

--- a/templates/coverage/cp_vs2_corners_emulf8.txt
+++ b/templates/coverage/cp_vs2_corners_emulf8.txt
@@ -1,0 +1,3 @@
+    cp_vs2_corners_emulf8 : coverpoint vs_corners_check(ins.hart, ins.issue, ins.current.vs2_val, "f8")  iff (ins.trap == 0 )  {
+        // Corners values of vs2 (emul = f8), assuming vl = 1
+    }

--- a/templates/coverage/cr_vs2_imm_corners.txt
+++ b/templates/coverage/cr_vs2_imm_corners.txt
@@ -1,0 +1,15 @@
+    cp_imm_corners_5bit : coverpoint signed'(ins.current.imm)  iff (ins.trap == 0 )  {
+        bins b_0 = {0};
+        bins b_1 = {1};
+        bins b_2 = {2};
+        bins b_14 = {14};
+        bins b_15 = {15};
+        bins b_n16 = {-16};
+        bins b_n15 = {-15};
+        bins b_n2 = {-2};
+        bins b_n1 = {-1};
+    }
+
+    cr_vs2_imm_corners : cross cp_vs2_corners,cp_imm_corners_5bit  iff (ins.trap == 0 )  {
+        //Cross coverage of VS2 corners and 5 bit imm corner values
+    }

--- a/templates/coverage/cr_vs2_imm_corners_u.txt
+++ b/templates/coverage/cr_vs2_imm_corners_u.txt
@@ -1,0 +1,13 @@
+    cp_imm_corners_5bit_u : coverpoint unsigned'(ins.current.imm)  iff (ins.trap == 0 )  {
+        bins b_0 = {0};
+        bins b_1 = {1};
+        bins b_2 = {2};
+        bins b_15 = {15};
+        bins b_16 = {16};
+        bins b_30 = {30};
+        bins b_31 = {31};
+    }
+
+    cr_vs2_imm_corners : cross cp_vs2_corners,cp_imm_corners_5bit_u  iff (ins.trap == 0 )  {
+        //Cross coverage of VS2 corners and 5 bit imm corner values (unsigned)
+    }

--- a/templates/coverage/cr_vs2_imm_corners_wi.txt
+++ b/templates/coverage/cr_vs2_imm_corners_wi.txt
@@ -1,0 +1,15 @@
+    cp_imm_corners_5bit : coverpoint signed'(ins.current.imm)  iff (ins.trap == 0 )  {
+        bins b_0 = {0};
+        bins b_1 = {1};
+        bins b_2 = {2};
+        bins b_14 = {14};
+        bins b_15 = {15};
+        bins b_n16 = {-16};
+        bins b_n15 = {-15};
+        bins b_n2 = {-2};
+        bins b_n1 = {-1};
+    }
+
+    cr_vs2_imm_corners_wi : cross cp_vs2_corners_emul2,cp_imm_corners_5bit  iff (ins.trap == 0 )  {
+        //Cross coverage of VS2 corners (emul = 2) and 5 bit imm corners values
+    }

--- a/templates/coverage/cr_vs2_imm_corners_wiu.txt
+++ b/templates/coverage/cr_vs2_imm_corners_wiu.txt
@@ -1,0 +1,13 @@
+    cp_imm_corners_5bit_u : coverpoint unsigned'(ins.current.imm)  iff (ins.trap == 0 )  {
+        bins b_0 = {0};
+        bins b_1 = {1};
+        bins b_2 = {2};
+        bins b_15 = {15};
+        bins b_16 = {16};
+        bins b_30 = {30};
+        bins b_31 = {31};
+    }
+
+    cr_vs2_imm_corners_wiu : cross cp_vs2_corners_emul2,cp_imm_corners_5bit_u  iff (ins.trap == 0 )  {
+        //Cross coverage of VS2 corners (emul = 2) and 5 bit imm corner values (unsigned)
+    }

--- a/templates/coverage/cr_vs2_rs1_corners.txt
+++ b/templates/coverage/cr_vs2_rs1_corners.txt
@@ -1,0 +1,3 @@
+    cr_vs2_rs1_corners : cross cp_vs2_corners,cp_rs1_corners  iff (ins.trap == 0 )  {
+        //Cross coverage of VS2 corners and RS1 corners
+    }

--- a/templates/coverage/cr_vs2_rs1_corners_wx.txt
+++ b/templates/coverage/cr_vs2_rs1_corners_wx.txt
@@ -1,0 +1,3 @@
+    cr_vs2_rs1_corners_wx : cross cp_vs2_corners_emul2,cp_rs1_corners  iff (ins.trap == 0 )  {
+        //Cross coverage of VS2 corners (emul = 2) and RS1 corners
+    }

--- a/templates/coverage/cr_vs2_vs1_corners.txt
+++ b/templates/coverage/cr_vs2_vs1_corners.txt
@@ -1,0 +1,3 @@
+    cr_vs2_vs1_corners : cross cp_vs2_corners,cp_vs1_corners  iff (ins.trap == 0 )  {
+        //Cross coverage of VS2 corners and VS1 corners
+    }

--- a/templates/coverage/cr_vs2_vs1_corners_mm.txt
+++ b/templates/coverage/cr_vs2_vs1_corners_mm.txt
@@ -1,0 +1,3 @@
+    cr_vs2_vs1_corners_mm : cross cp_vs2_corners_eew1,cp_vs1_corners_eew1  iff (ins.trap == 0 )  {
+        //Cross coverage of VS2 corners (eew = 1) and VS1 corners (eew = 1)
+    }

--- a/templates/coverage/cr_vs2_vs1_corners_wred.txt
+++ b/templates/coverage/cr_vs2_vs1_corners_wred.txt
@@ -1,0 +1,3 @@
+    cr_vs2_vs1_corners_wred : cross cp_vs2_corners,cp_vs1_corners_emul2  iff (ins.trap == 0 )  {
+        //Cross coverage of VS2 corners and VS1 corners (emul = 2)
+    }

--- a/templates/coverage/cr_vs2_vs1_corners_wv.txt
+++ b/templates/coverage/cr_vs2_vs1_corners_wv.txt
@@ -1,0 +1,3 @@
+    cr_vs2_vs1_corners_wv : cross cp_vs2_corners_emul2,cp_vs1_corners  iff (ins.trap == 0 )  {
+        //Cross coverage of VS2 corners (emul = 2) and VS1 corners
+    }

--- a/templates/coverage/cr_vxrm_vs2_imm_corners.txt
+++ b/templates/coverage/cr_vxrm_vs2_imm_corners.txt
@@ -1,0 +1,11 @@
+    cp_csr_vxrm : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_AFTER, "vcsr", "vxrm")  iff (ins.trap == 0)  {
+        // Value of VCSR.vxrm (vector fixed-point rounding mode)
+        bins rnu  = {2'b00};
+        bins rne  = {2'b01};
+        bins rdn  = {2'b10};
+        bins rod  = {2'b11};
+    }
+
+    cr_vxrm_vs2_imm_corners : cross cp_vs2_corners,cp_imm_corners_5bit_u,cp_csr_vxrm  iff (ins.trap == 0 )  {
+        //Cross coverage VS2, imm corners (unsigned), rounding mode
+    }

--- a/templates/coverage/cr_vxrm_vs2_imm_corners_wi.txt
+++ b/templates/coverage/cr_vxrm_vs2_imm_corners_wi.txt
@@ -1,0 +1,12 @@
+    cp_csr_vxrm : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_AFTER, "vcsr", "vxrm")  iff (ins.trap == 0)  {
+        // Value of VCSR.vxrm (vector fixed-point rounding mode)
+        bins rnu  = {2'b00};
+        bins rne  = {2'b01};
+        bins rdn  = {2'b10};
+        bins rod  = {2'b11};
+    }
+
+
+    cr_vxrm_vs2_imm_corners_wi : cross cp_vs2_corners_emul2,cp_imm_corners_5bit_u,cp_csr_vxrm  iff (ins.trap == 0 )  {
+        //Cross coverage VS2 (emul = 2), imm corners (unsigned), rounding mode
+    }

--- a/templates/coverage/cr_vxrm_vs2_rs1_corners.txt
+++ b/templates/coverage/cr_vxrm_vs2_rs1_corners.txt
@@ -1,0 +1,11 @@
+    cp_csr_vxrm : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_AFTER, "vcsr", "vxrm")  iff (ins.trap == 0)  {
+        // Value of VCSR.vxrm (vector fixed-point rounding mode)
+        bins rnu  = {2'b00};
+        bins rne  = {2'b01};
+        bins rdn  = {2'b10};
+        bins rod  = {2'b11};
+    }
+
+    cr_vxrm_vs2_rs1_corners : cross cp_vs2_corners,cp_rs1_corners,cp_csr_vxrm  iff (ins.trap == 0 )  {
+        //Cross coverage VS2, RS1, rounding mode
+    }

--- a/templates/coverage/cr_vxrm_vs2_rs1_corners_wx.txt
+++ b/templates/coverage/cr_vxrm_vs2_rs1_corners_wx.txt
@@ -1,0 +1,11 @@
+    cp_csr_vxrm : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_AFTER, "vcsr", "vxrm")  iff (ins.trap == 0)  {
+        // Value of VCSR.vxrm (vector fixed-point rounding mode)
+        bins rnu  = {2'b00};
+        bins rne  = {2'b01};
+        bins rdn  = {2'b10};
+        bins rod  = {2'b11};
+    }
+
+    cr_vxrm_vs2_rs1_corners_wx : cross cp_vs2_corners_emul2,cp_rs1_corners,cp_csr_vxrm  iff (ins.trap == 0 )  {
+        //Cross coverage VS2 (emul = 2), RS1, rounding mode
+    }

--- a/templates/coverage/cr_vxrm_vs2_vs1_corners.txt
+++ b/templates/coverage/cr_vxrm_vs2_vs1_corners.txt
@@ -1,0 +1,11 @@
+    cp_csr_vxrm : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_AFTER, "vcsr", "vxrm")  iff (ins.trap == 0)  {
+        // Value of VCSR.vxrm (vector fixed-point rounding mode)
+        bins rnu  = {2'b00};
+        bins rne  = {2'b01};
+        bins rdn  = {2'b10};
+        bins rod  = {2'b11};
+    }
+
+    cr_vxrm_vs2_vs1_corners : cross cp_vs2_corners,cp_vs1_corners,cp_csr_vxrm  iff (ins.trap == 0 )  {
+        //Cross coverage VS2, VS1, rounding mode
+    }

--- a/templates/coverage/cr_vxrm_vs2_vs1_corners_wv.txt
+++ b/templates/coverage/cr_vxrm_vs2_vs1_corners_wv.txt
@@ -1,0 +1,11 @@
+    cp_csr_vxrm : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_AFTER, "vcsr", "vxrm")  iff (ins.trap == 0)  {
+        // Value of VCSR.vxrm (vector fixed-point rounding mode)
+        bins rnu  = {2'b00};
+        bins rne  = {2'b01};
+        bins rdn  = {2'b10};
+        bins rod  = {2'b11};
+    }
+
+    cr_vxrm_vs2_vs1_corners_wv : cross cp_vs2_corners_emul2,cp_vs1_corners,cp_csr_vxrm  iff (ins.trap == 0 )  {
+        //Cross coverage VS2 (emul = 2), VS1, rounding mode
+    }


### PR DESCRIPTION
- updating VLEN to 512 instead of 256 since sail is using 512
- first draft of vector corner value coverpoints and tests
-- collecting coverage, not 100% because rvviTrace is having issues updating the vector values and thus the coverpoints are not recognizing their values (confirmed in sail trace file that the vectors are getting correct values)