### PR TITLE
Fixed critical error on testbench having XLEN for all types of registers

### DIFF
--- a/bin/sail-parse.py
+++ b/bin/sail-parse.py
@@ -22,7 +22,7 @@ def sailLog2Trace(inputLogFile, outputTraceFile):
         'CSR': re.compile(r'CSR .* \((0x[0-9a-fA-F]+)\) (?:<-|->) (0x[0-9a-fA-F]+)'),
         'X': re.compile(r'x(\d+) <- (0x[0-9a-fA-F]+)'),
         'F': re.compile(r'f(\d+) <- (0x[0-9a-fA-F]+)'),
-        'V': re.compile(r'v(\d+) <- ([0-9a-fA-F]+)'),
+        'V': re.compile(r'v(\d+) <- (0x[0-9a-fA-F]+)'),
     }
 
     # Mode mapping

--- a/bin/sail-parse.py
+++ b/bin/sail-parse.py
@@ -22,7 +22,7 @@ def sailLog2Trace(inputLogFile, outputTraceFile):
         'CSR': re.compile(r'CSR .* \((0x[0-9a-fA-F]+)\) (?:<-|->) (0x[0-9a-fA-F]+)'),
         'X': re.compile(r'x(\d+) <- (0x[0-9a-fA-F]+)'),
         'F': re.compile(r'f(\d+) <- (0x[0-9a-fA-F]+)'),
-        'V': re.compile(r'v(\d+) <- (0x[0-9a-fA-F]+)'),
+        'V': re.compile(r'v(\d+) <- ([0-9a-fA-F]+)'),
     }
 
     # Mode mapping

--- a/bin/sail-parse.py
+++ b/bin/sail-parse.py
@@ -19,7 +19,7 @@ def sailLog2Trace(inputLogFile, outputTraceFile):
 
     # Regular expressions to match register updates
     reg_patterns = {
-        'CSR': re.compile(r'CSR .* \(0x(\d+)\) <- (0x[0-9a-fA-F]+)'),
+        'CSR': re.compile(r'CSR .* \((0x[0-9a-fA-F]+)\) (?:<-|->) (0x[0-9a-fA-F]+)'),
         'X': re.compile(r'x(\d+) <- (0x[0-9a-fA-F]+)'),
         'F': re.compile(r'f(\d+) <- (0x[0-9a-fA-F]+)'),
         'V': re.compile(r'v(\d+) <- (0x[0-9a-fA-F]+)'),

--- a/fcov/testbench.sv
+++ b/fcov/testbench.sv
@@ -180,13 +180,10 @@ module testbench;
             val = words.pop_front();
             num = $sscanf(val, "%h", vRegVal);
             v_wdata[regNum] = vRegVal;
-            $display("VLEN: %0d", VLEN);
-            $display("v_wdata: %h", vRegVal);
             v_wb |= (1 << regNum);
           end
           "CSR": begin
             num = $sscanf(val, "%h", regNum);
-            $display("CSR: %h", regNum);
             val = words.pop_front();
             num = $sscanf(val, "%h", xRegVal);
             csr[regNum] = xRegVal;

--- a/fcov/testbench.sv
+++ b/fcov/testbench.sv
@@ -50,7 +50,9 @@ module testbench;
   string  words[$];
   int     order;
   int     regNum;
-  logic [(XLEN-1):0] regVal;
+  logic [(XLEN-1):0] xRegVal;
+  logic [(FLEN-1):0] fRegVal;
+  logic [(VLEN-1):0] vRegVal;
 
   // RVVI Trace interface signals
   // Basic signals
@@ -162,30 +164,32 @@ module testbench;
           "X": begin
             num = $sscanf(val, "%d", regNum);
             val = words.pop_front();
-            num = $sscanf(val, "%h", regVal);
-            x_wdata[regNum] = regVal;
+            num = $sscanf(val, "%h", xRegVal);
+            x_wdata[regNum] = xRegVal;
             x_wb |= (1 << regNum);
           end
           "F": begin
             num = $sscanf(val, "%d", regNum);
             val = words.pop_front();
-            num = $sscanf(val, "%h", regVal);
-            f_wdata[regNum] = regVal;
+            num = $sscanf(val, "%h", fRegVal);
+            f_wdata[regNum] = fRegVal;
             f_wb |= (1 << regNum);
           end
           "V": begin
             num = $sscanf(val, "%d", regNum);
             val = words.pop_front();
-            num = $sscanf(val, "%h", regVal);
-            v_wdata[regNum] = regVal;
+            num = $sscanf(val, "%h", vRegVal);
+            v_wdata[regNum] = vRegVal;
+            $display("VLEN: %0d", VLEN);
+            $display("v_wdata: %h", vRegVal);
             v_wb |= (1 << regNum);
           end
           "CSR": begin
             num = $sscanf(val, "%h", regNum);
             $display("CSR: %h", regNum);
             val = words.pop_front();
-            num = $sscanf(val, "%h", regVal);
-            csr[regNum] = regVal;
+            num = $sscanf(val, "%h", xRegVal);
+            csr[regNum] = xRegVal;
             csr_wb |= (1 << regNum);
           end
           default: begin


### PR DESCRIPTION
In testbench.sv, all regVal was assigned to be XLEN long, which cuts the values held by double FP and vector registers, and causing issues with coverage.

sail parsing errors are also included in this PR.