### PR TITLE
Correcting fractional lmul mistake

### DIFF
--- a/fcov/coverage/RISCV_coverage_standard_coverpoints_vector.svh
+++ b/fcov/coverage/RISCV_coverage_standard_coverpoints_vector.svh
@@ -133,7 +133,7 @@
         bins eight  = {3};
     }
 
-    vtype_all_lmul_supported : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "vtype", "vlmul") {
+    vtype_all_lmul_supported_sew8 : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "vtype", "vlmul") {
         `ifdef LMULf8_SUPPORTED
         bins eigth  = {5};
         `endif
@@ -143,6 +143,36 @@
         `ifdef LMULf2_SUPPORTED
         bins half   = {7};
         `endif
+        bins one    = {0};
+        bins two    = {1};
+        bins four   = {2};
+        bins eight  = {3};
+    }
+
+    vtype_all_lmul_supported_sew16 : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "vtype", "vlmul") {
+        `ifdef LMULf4_SUPPORTED
+        bins fourth = {6};
+        `endif
+        `ifdef LMULf2_SUPPORTED
+        bins half   = {7};
+        `endif
+        bins one    = {0};
+        bins two    = {1};
+        bins four   = {2};
+        bins eight  = {3};
+    }
+
+    vtype_all_lmul_supported_sew32 : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "vtype", "vlmul") {
+        `ifdef LMULf2_SUPPORTED
+        bins half   = {7};
+        `endif
+        bins one    = {0};
+        bins two    = {1};
+        bins four   = {2};
+        bins eight  = {3};
+    }
+
+    vtype_all_lmul_supported_sew64 : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "vtype", "vlmul") {
         bins one    = {0};
         bins two    = {1};
         bins four   = {2};
@@ -185,7 +215,25 @@
 
     vtype_sew_8: coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "vtype", "vsew") {
         `ifdef SEW8_SUPPORTED
-        bins eight      = {0};
+        bins eight = {0};
+        `endif
+    }
+
+    vtype_sew_16: coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "vtype", "vsew") {
+        `ifdef SEW16_SUPPORTED
+        bins sixteen = {1};
+        `endif
+    }
+
+    vtype_sew_32: coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "vtype", "vsew") {
+        `ifdef SEW32_SUPPORTED
+        bins thirtytwo = {2};
+        `endif
+    }
+
+    vtype_sew_64: coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "vtype", "vsew") {
+        `ifdef SEW64_SUPPORTED
+        bins sixtyfour = {3};
         `endif
     }
 

--- a/fcov/priv/ZicsrV_coverage.svh
+++ b/fcov/priv/ZicsrV_coverage.svh
@@ -230,8 +230,12 @@ covergroup ZicsrV_cg with function sample(ins_t ins);
                                             bins true = {1};
                                         }
 
-    cp_vset_i_vli_rd_n0_rs1_x0 : cross vset_i_vli_instructions, vl_not_max, rd_n0, rs1_x0, vtype_all_sew_supported, vtype_all_lmul_supported;
-    cp_vset_i_vli_rd_x0_rs1_x0 : cross vset_i_vli_instructions, vl_nonzero, rd_x0, rs1_x0, vset_i_vli_vlmax_unchanged;
+    cp_vset_i_vli_rd_n0_rs1_x0_sew8  : cross vset_i_vli_instructions, vl_not_max, rd_n0, rs1_x0, vtype_sew_8,  vtype_all_lmul_supported_sew8;
+    cp_vset_i_vli_rd_n0_rs1_x0_sew16 : cross vset_i_vli_instructions, vl_not_max, rd_n0, rs1_x0, vtype_sew_16, vtype_all_lmul_supported_sew16;
+    cp_vset_i_vli_rd_n0_rs1_x0_sew32 : cross vset_i_vli_instructions, vl_not_max, rd_n0, rs1_x0, vtype_sew_32, vtype_all_lmul_supported_sew32;
+    cp_vset_i_vli_rd_n0_rs1_x0_sew64 : cross vset_i_vli_instructions, vl_not_max, rd_n0, rs1_x0, vtype_sew_64, vtype_all_lmul_supported_sew64;
+
+    cp_vset_i_vli_rd_x0_rs1_x0       : cross vset_i_vli_instructions, vl_nonzero, rd_x0, rs1_x0, vset_i_vli_vlmax_unchanged;
 
     //////////////////////////////////////////////////////////////////////////////////
     // cp_vsetvl_i_avl_*


### PR DESCRIPTION
Misread spec to say all fractional lmuls were supported for all sew, when in reality certain fractional lmuls only exist for some - this has been confirmed by both georgia and prof harris. 

This pr is the corrected coverpoint in priv that was only supposed to check supported lmul