### PR TITLE
Fixed vlmax function naming and changed vill consequence

### DIFF
--- a/fcov/coverage/RISCV_coverage_standard_coverpoints_vector.svh
+++ b/fcov/coverage/RISCV_coverage_standard_coverpoints_vector.svh
@@ -117,12 +117,12 @@
 
 
     vl_max: coverpoint (get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "vl", "vl")
-                        == get_vlmax(ins.hart, ins.issue, `SAMPLE_BEFORE)) {
+                        == get_vtype_vlmax(ins.hart, ins.issue, `SAMPLE_BEFORE)) {
         bins target = {1'b1};
     }
 
     vl_not_max: coverpoint (get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "vl", "vl") ==
-                            get_vlmax(ins.hart, ins.issue, `SAMPLE_BEFORE)) {
+                            get_vtype_vlmax(ins.hart, ins.issue, `SAMPLE_BEFORE)) {
         bins target = {1'b0};
     }
 

--- a/fcov/coverage/RISCV_coverage_vector.svh
+++ b/fcov/coverage/RISCV_coverage_vector.svh
@@ -20,7 +20,7 @@
 //
 //
 
-function int get_vlmax(int hart, int issue, int prev);
+function int get_vtype_vlmax(int hart, int issue, int prev);
 
   logic[2:0] vsew  = get_csr_val(hart, issue, prev, "vtype", "vsew") [2:0];
   logic[2:0] vlmul = get_csr_val(hart, issue, prev, "vtype", "vlmul")[2:0];
@@ -34,7 +34,7 @@ function int get_vlmax(int hart, int issue, int prev);
         3'b110: begin end
         3'b111: begin end
         default: begin
-            $display("ERROR: SystemVerilog Functional Coverage: get_vlmax lmul is undefined (%0s)", vlmul);
+            $display("ERROR: SystemVerilog Functional Coverage: get_vtype_vlmax lmul is undefined (%0s)", vlmul);
             $finish(-1);
         end
     endcase
@@ -45,14 +45,13 @@ function int get_vlmax(int hart, int issue, int prev);
         3'b010: begin end
         3'b011: begin end
         default: begin
-            $display("ERROR: SystemVerilog Functional Coverage: get_vlmax sew is undefined (%0s)", vsew);
+            $display("ERROR: SystemVerilog Functional Coverage: get_vtype_vlmax sew is undefined (%0s)", vsew);
             $finish(-1);
         end
     endcase
 
   if(get_csr_val(hart, issue, prev, "vtype", "vill") == 1) begin
-    $display("ERROR: SystemVerilog Functional Coverage: vlmax undefined, vill bit is set");
-    $finish(-1);
+    return -1;   // make sure no coverpoint can ever be hit when vill bit is set
   end
 
   return get_vlmax_params(hart, issue, vsew, vlmul);
@@ -278,7 +277,7 @@ typedef enum {
 
 // Check for vector operand corner values, assuming vl = 1
 function corner_mask_values_t mask_corners_check(int hart, int issue, `VLEN_BITS mask_val);
-  int vlmax = get_vlmax(hart, issue, `SAMPLE_BEFORE);
+  int vlmax = get_vtype_vlmax(hart, issue, `SAMPLE_BEFORE);
 
   if      (mask_val == 0)                           return mask_zero;
   else if (mask_val == ((2 ** (vlmax)) - 1))        return mask_ones;
@@ -300,7 +299,7 @@ typedef enum {
 function vl_t vl_check(int hart, int issue);
   `XLEN_BITS vl = get_csr_val(hart, issue, `SAMPLE_BEFORE, "vl", "vl");
   `XLEN_BITS vstart = get_csr_val(hart, issue, `SAMPLE_BEFORE, "vstart", "vstart");
-  int vlmax = get_vlmax(hart, issue, `SAMPLE_BEFORE);
+  int vlmax = get_vtype_vlmax(hart, issue, `SAMPLE_BEFORE);
   bit legal;
   if (vl <= vlmax & vl > vstart) legal = 1'b1; // check legal condition
   else                           legal = 1'b0;

--- a/fcov/priv/ZicsrV_coverage.svh
+++ b/fcov/priv/ZicsrV_coverage.svh
@@ -225,7 +225,7 @@ covergroup ZicsrV_cg with function sample(ins_t ins);
         bins zero = {0};
     }
 
-    vset_i_vli_vlmax_unchanged : coverpoint (get_vlmax(ins.hart, ins.issue, `SAMPLE_BEFORE)
+    vset_i_vli_vlmax_unchanged : coverpoint (get_vtype_vlmax(ins.hart, ins.issue, `SAMPLE_BEFORE)
                                         == get_vlmax_params(ins.hart, ins.issue, ins.current.insn[25:23], ins.current.insn[22:20])) {
                                             bins true = {1};
                                         }
@@ -238,16 +238,16 @@ covergroup ZicsrV_cg with function sample(ins_t ins);
     // tests corner case avl behavior on the vset instructions
     //////////////////////////////////////////////////////////////////////////////////
 
-    rs1_le_vlmax : coverpoint (ins.current.rs1_val <= get_vlmax(ins.hart, ins.issue, `SAMPLE_BEFORE)) {
+    rs1_le_vlmax : coverpoint (ins.current.rs1_val <= get_vtype_vlmax(ins.hart, ins.issue, `SAMPLE_BEFORE)) {
         bins true = {1};
     }
 
-    rs1_lt_2x_vlmax_gt_vlmax : coverpoint (ins.current.rs1_val < 2 * get_vlmax(ins.hart, ins.issue, `SAMPLE_BEFORE)
-                                        & ins.current.rs1_val > get_vlmax(ins.hart, ins.issue, `SAMPLE_BEFORE)) {
+    rs1_lt_2x_vlmax_gt_vlmax : coverpoint (ins.current.rs1_val < 2 * get_vtype_vlmax(ins.hart, ins.issue, `SAMPLE_BEFORE)
+                                        & ins.current.rs1_val > get_vtype_vlmax(ins.hart, ins.issue, `SAMPLE_BEFORE)) {
         bins true = {1};
     }
 
-    rs1_ge_2x_vlmax : coverpoint (ins.current.rs1_val >= 2 * get_vlmax(ins.hart, ins.issue, `SAMPLE_BEFORE)) {
+    rs1_ge_2x_vlmax : coverpoint (ins.current.rs1_val >= 2 * get_vtype_vlmax(ins.hart, ins.issue, `SAMPLE_BEFORE)) {
         bins true = {1};
     }
 


### PR DESCRIPTION
Changed naming of get_vlmax to get_vtype_vlmax to make clear that the vlmax is being calculated from the current CSR values.

The function used to terminate vsim if vill bit is set, which is causing an issue in priv tests. Changed vlmax to return -1 if vill bit is set.