### PR TITLE
Zcf extension fixes + cleanup

### DIFF
--- a/bin/testgen.py
+++ b/bin/testgen.py
@@ -404,17 +404,21 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
       lines = lines + "csrr x" + str(rs2) + ", mscratch #Reading the updated mscratch value \n"
       lines += writeSIGUPD(rs2)
   elif (test in citype):
+    if "sp" in test: #ensure no sp conflicts
+      while rs1 == 2 or rs2 == 2:
+        rs1 = randint(1,31)
+        rs2 = randint(1,31)
     if(test == "c.lui" and rd == 2): # rd ==2 is illegal operand
       rd = 9 # change to arbitrary other register
     elif (test == "c.addiw" and rd == 0):
       rd = 1
     if (test != "c.addi16sp"):
-      if (test in "c.lwsp"):
-        lines = lines + "li x" + str(rs2) + ", " + formatstr.format(rdval) + " # initialize rs1\n"
+      if (test == "c.lwsp" or test == "c.flwsp"):
+        lines = lines + "li x" + str(rs2) + ", " + formatstr.format(rdval) + " # initialize rs2\n"
       else:
-        lines = lines + "li x" + str(rd) + ", " + formatstr.format(rdval) + " # initialize rs1\n"
+        lines = lines + "li x" + str(rd) + ", " + formatstr.format(rdval) + " # initialize rd\n"
     if (test == "c.addi16sp"):
-      lines = lines + "li" + " sp"  + ", " + formatstr.format(rdval) + " # initialize rs1\n"
+      lines = lines + "li" + " sp"  + ", " + formatstr.format(rdval) + " # initialize sp\n"
       immval = int(signedImm6(immval)) * 16
       if (immval == 0):
         immval = 16
@@ -555,7 +559,7 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
         lines = lines + "addi x"     + str(rs1) + ", x" + str(rs1) + ", -" + str(int(unsignedImm5(immval))*mul) + " # sub immediate from rs1 to counter offset\n"
         lines = lines + "li x" + str(rs2) + ", " + formatstr.format(rs2val) + " # load immediate value into integer register\n"
         lines = lines + "sw x" + str(rs2) + ", " + str(int(unsignedImm5(immval))*mul) + "(x" + str(rs1) + ") # store value to memory\n"
-        lines = writeTest(lines, rd, xlen, False,  test + " f" + str(rd)  + ", " + str(int(unsignedImm5(immval))*mul) + "(x" + str(rs1) + ") # perform operation\n")
+        lines = writeTest(lines, rd, xlen, True,  test + " f" + str(rd)  + ", " + str(int(unsignedImm5(immval))*mul) + "(x" + str(rs1) + ") # perform operation\n")
       elif (test == "c.fld"):
         storeop =  "sw" if (min (xlen, flen) == 32) else "sd"
         mul = 8
@@ -666,9 +670,10 @@ def writeCovVector(desc, rs1, rs2, rd, rs1val, rs2val, immval, rdval, test, xlen
     lines = writeStoreTest(lines, test, rs2, xlen, storeline)
     lines = lines + f"addi sp, sp, {offset} # offset stack pointer from signature\n"
     if test in ["c.sd", "c.fsd","c.sdsp", "c.fsdsp"]:
-        WIDTH = 64
+        sigupd_count += 1
+        WIDTH = 8
     else:
-        WIDTH = 32
+        WIDTH = "REGWIDTH"
     lines = lines + "addi x" + str(sigReg) + ", x"  + str(sigReg) + ", " + str(WIDTH)   + " # Incrementing base register\n"
     sigupd_count += 1
 


### PR DESCRIPTION
ensure no sp load conflicts with sp instructions

c.flwsp needs to load to rs2 not rd.

comment cleanup

c.flw is a float instruction so writeTest puts the right SIGUPD_F

fix incrementing to byte size