### PR TITLE
Fix Sail priv mode parsing for coverage

### DIFF
--- a/fcov/testbench.sv
+++ b/fcov/testbench.sv
@@ -136,6 +136,7 @@ module testbench;
         // doesn't work for number larger than 32 bits
         case(key)
           // Standard signals
+          "ORDER":          num = $sscanf(val, "%d", order);
           "INSN":           num = $sscanf(val, "%h", insn);
           "TRAP":           num = $sscanf(val, "%b", trap);
           "DEBUG_MODE":     num = $sscanf(val, "%b", debug_mode);
@@ -195,7 +196,6 @@ module testbench;
           end
         endcase
       end
-      order++;
       valid = 1;
     end else begin
       $display("Skipping empty line");


### PR DESCRIPTION
Use the priv mode from the next instruction (which is the priv mode the current instruction ends in) as RVVI expects.