### PR TITLE
Migrate ruff config and add Make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,3 +155,9 @@ clean:
 	rm -rf $(SRCDIR64) $(SRCDIR32) $(PRIVHEADERSDIR) $(PRIVDIR64) $(PRIVDIR32) $(WORK)
 	rm -rf ${WALLY}/addins/cvw-riscv-arch-test/riscv-test-suite/rv32i/*
 	rm -rf ${WALLY}/addins/cvw-riscv-arch-test/riscv-test-suite/rv64i/*
+
+lint:
+	uvx ruff check
+
+lint-fix:
+	uvx ruff check --fix

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ SOURCEFILE = $(subst priv/rv64/,priv/,$(subst priv/rv32/,priv/,$*)).S
 sim:
 	rm -f ${WALLY}/sim/questa/fcov_ucdb/*
 # Modify the following line to run a specific test
-	wsim rv32gc $(TESTDIR)/rv32/I/WALLY-COV-I-add.elf --fcov --lockstepverbose --define "+define+FCOV_VERBOSE"
+	wsim rv32gc $(TESTDIR)/rv32/I/I-add.elf --fcov --lockstepverbose --define "+define+FCOV_VERBOSE"
 
 	$(MAKE) merge
 

--- a/bin/sail-parse.py
+++ b/bin/sail-parse.py
@@ -9,30 +9,31 @@
 # with RVVI input to cvw-arch-verif
 ##################################
 
+import argparse
 import re
-import sys
+from pathlib import Path
 
 
-def sailLog2Trace(inputLogFile, outputTraceFile):
+def sailLog2Trace(inputLogFile: Path, outputTraceFile: Path) -> None:
     # Regular expression to match instruction lines
     #                             [STEP]     [MODE]:    0xPC              (0xINSN)           DISASM
-    insn_pattern = re.compile(r'\[(\d+)\] \[([MSU])\]: 0x([0-9a-fA-F]+) \(0x([0-9a-fA-F]+)\) (.*)')
+    insn_pattern = re.compile(r"\[(\d+)\] \[([MSU])\]: 0x([0-9a-fA-F]+) \(0x([0-9a-fA-F]+)\) (.*)")
 
     # Regular expressions to match register updates
     reg_patterns = {
-        'CSR': re.compile(r'CSR .* \(0x([0-9a-fA-F]+)\) (?:<-|->) 0x([0-9a-fA-F]+)'),
-        'X':   re.compile(r'x(\d+) <- 0x([0-9a-fA-F]+)'),
-        'F':   re.compile(r'f(\d+) <- 0x([0-9a-fA-F]+)'),
-        'V':   re.compile(r'v(\d+) <- 0x([0-9a-fA-F]+)'),
+        "CSR": re.compile(r"CSR .* \(0x([0-9a-fA-F]+)\) (?:<-|->) 0x([0-9a-fA-F]+)"),
+        "X": re.compile(r"x(\d+) <- 0x([0-9a-fA-F]+)"),
+        "F": re.compile(r"f(\d+) <- 0x([0-9a-fA-F]+)"),
+        "V": re.compile(r"v(\d+) <- 0x([0-9a-fA-F]+)"),
     }
 
     # Mode mapping
-    mode_map = {'M': '3', 'S': '1', 'U': '0'}
+    mode_map = {"M": "3", "S": "1", "U": "0"}
 
     # TODO: Add support for parsing traps, interrupts, and VM signals
 
     # Main parsing of log file
-    with open(inputLogFile) as f, open(outputTraceFile, "w") as outfile:
+    with inputLogFile.open() as f, outputTraceFile.open("w") as outfile:
         lines = f.readlines()
         output_line = ""
         for i in range(len(lines)):
@@ -73,10 +74,15 @@ def sailLog2Trace(inputLogFile, outputTraceFile):
                 outfile.write(output_line)
                 output_line = next_output
 
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert a Sail log file into a trace format for use with RVVI")
+    parser.add_argument("input_file", type=Path, help="Input Sail log file to parse")
+    parser.add_argument("output_file", type=Path, help="Output trace file for RVVI")
+    args = parser.parse_args()
+
+    sailLog2Trace(args.input_file, args.output_file)
+
+
 if __name__ == "__main__":
-    if len(sys.argv) == 3:
-        input_file = sys.argv[1]
-        output_file = sys.argv[2]
-        sailLog2Trace(input_file, output_file)
-    else:
-        print("Invalid number of arguments. \nUsage: sail-parse.py <input_log_file> <output_trace_file>")
+    main()

--- a/bin/vector-testgen-unpriv.py
+++ b/bin/vector-testgen-unpriv.py
@@ -1165,7 +1165,7 @@ if __name__ == '__main__':
         else:
           immcornersv = [0, 1, 2, 14, 15, -1, -2, -15, -16]
 
-        basename = "WALLY-COV-" + extension + "-" + test
+        basename = extension + "-" + test
         fname = pathname + "/" + basename + ".S"
         tempfname = pathname + "/" + basename + "_temp.S"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
-# TODO: Migrate this whole file to pyproject.toml when swithcing to new project structure
-
+[tool.ruff]
 # Target oldest version of Python used (Python 3.9 for Ubuntu 20.04 LTS)
 target-version = "py312"
 
-line-length=250
+line-length = 250
 
-[lint]
+[tool.ruff.lint]
 select = [
   "F",    # various basic rules (pyflakes)
   "E",    # errors (pycodestyle)


### PR DESCRIPTION
- Migrate `.ruff.toml` to `pyproject.toml` so a single file can be used for all python related configuration going forward.
- Add `make lint` and `make lint-fix` targets to make it easy to manually run lint.