### PR TITLE
Modified VM_Exceptions covergroups

### DIFF
--- a/fcov/priv/ExceptionsVMZaamo_coverage.svh
+++ b/fcov/priv/ExceptionsVMZaamo_coverage.svh
@@ -21,7 +21,7 @@
 // and limitations under the License.
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-`define COVER_EXCEPTIONSVM
+`define COVER_EXCEPTIONSVMZAAMO
 covergroup ExceptionsVMZaamo_cg with function sample(ins_t ins);
     option.per_instance = 0;
     `include "coverage/RISCV_coverage_standard_coverpoints.svh"
@@ -69,16 +69,6 @@ covergroup ExceptionsVMZaamo_cg with function sample(ins_t ins);
         // bit 14 reserved
         bins storepagefault_enabled   = {16'b1000_0000_0000_0000};
         wildcard bins ones            = {16'b1011_0001_1111_111?};
-    }
-
-    d_page_table_entry_bad: coverpoint ins.current.pte_d[7:0] {
-        bins invalid = {8'b00000000}; // invalid
-    }
-
-    d_phys_address: coverpoint ins.current.phys_adr_d[11:0] {
-        // check that fault occurs on the last halfword of the first page and the first halfword of the second page
-        bins first  = {12'b111111111110};
-        bins second = {12'b000000000000};
     }
 
     // main coverpoints

--- a/fcov/priv/ExceptionsVMZalrsc_coverage.svh
+++ b/fcov/priv/ExceptionsVMZalrsc_coverage.svh
@@ -21,7 +21,7 @@
 // and limitations under the License.
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-`define COVER_EXCEPTIONSVM
+`define COVER_EXCEPTIONSVMZALRSC
 covergroup ExceptionsVMZalrsc_cg with function sample(ins_t ins);
     option.per_instance = 0;
     `include "coverage/RISCV_coverage_standard_coverpoints.svh"
@@ -70,14 +70,6 @@ covergroup ExceptionsVMZalrsc_cg with function sample(ins_t ins);
         // bit 14 reserved
         bins storepagefault_enabled   = {16'b1000_0000_0000_0000};
         wildcard bins ones            = {16'b1011_0001_1111_111?};
-    }
-    d_page_table_entry_bad: coverpoint ins.current.pte_d[7:0] {
-        bins invalid = {8'b00000000}; // invalid
-    }
-    d_phys_address: coverpoint ins.current.phys_adr_d[11:0] {
-        // check that fault occurs on the last halfword of the first page and the first halfword of the second page
-        bins first  = {12'b111111111110};
-        bins second = {12'b000000000000};
     }
 
     // main coverpoints

--- a/fcov/priv/ExceptionsVM_coverage.svh
+++ b/fcov/priv/ExceptionsVM_coverage.svh
@@ -112,12 +112,10 @@ covergroup ExceptionsVM_cg with function sample(ins_t ins);
     sw: coverpoint ins.current.insn {
         wildcard bins sw = {32'b????????????_?????_010_?????_0100011};
     }
-    jalr: coverpoint ins.current.insn {
+    jalr: coverpoint ins.prev.insn {
         wildcard bins jalr = {32'b????????????_?????_000_?????_1100111};
     }
-    misaligned_pagespanning_address: coverpoint  {ins.current.imm + ins.current.rs1_val}[11:0] {
-        bins misaligned = {12'b111111111110};
-    }
+
     d_page_table_entry_bad: coverpoint ins.current.pte_d[7:0] {
         bins invalid = {8'b00000000}; // invalid
     }
@@ -140,13 +138,10 @@ covergroup ExceptionsVM_cg with function sample(ins_t ins);
 
 
     // main coverpoints
-    cp_instr_page_fault_m:           cross priv_mode_m, mstatus_mprv_one, mstatus_mpp, instr_page_fault;
     cp_load_page_fault_m:            cross priv_mode_m, mstatus_mprv_one, mstatus_mpp, load_page_fault;
     cp_store_page_fault_m:           cross priv_mode_m, mstatus_mprv_one, mstatus_mpp, store_page_fault;
     cp_misaligned_priority_m:        cross priv_mode_m, memops, d_virt_adr_misaligned, d_page_table_entry_invalid, d_phys_address_nonexistant;
-    cp_misaligned_priority_fetch_m:  cross priv_mode_m, i_virt_adr_misaligned, i_page_table_entry_invalid, i_phys_address_nonexistant;
     cp_medeleg_m:                    cross priv_mode_m, memops,  d_page_table_entry_invalid, medeleg_walk;
-    cp_medeleg_fetch_m:              cross priv_mode_m, i_page_table_entry_invalid, medeleg_walk;
     cp_instr_page_fault_s:           cross priv_mode_s, instr_page_fault;
     cp_load_page_fault_s:            cross priv_mode_s, load_page_fault;
     cp_store_page_fault_s:           cross priv_mode_s, store_page_fault;
@@ -154,9 +149,9 @@ covergroup ExceptionsVM_cg with function sample(ins_t ins);
     cp_misaligned_priority_fetch_s:  cross priv_mode_s, i_virt_adr_misaligned, i_page_table_entry_invalid, i_phys_address_nonexistant;
     cp_medeleg_s:                    cross priv_mode_s, memops, d_page_table_entry_invalid, medeleg_walk;
     cp_medeleg_fetch_s:              cross priv_mode_s, i_page_table_entry_invalid, medeleg_walk;
-    cp_misaligned_load_page_fault_s: cross priv_mode_s, d_page_table_entry_bad, misaligned_pagespanning_address, d_phys_address, lw;
-    cp_misaligned_store_page_fault_s:cross priv_mode_s, d_page_table_entry_bad, misaligned_pagespanning_address, d_phys_address, sw;
-    cp_misaligned_inst_page_fault_s: cross priv_mode_s, i_page_table_entry_bad, misaligned_pagespanning_address, i_phys_address, jalr;
+    cp_misaligned_load_page_fault_s: cross priv_mode_s, d_page_table_entry_bad, d_phys_address, lw;
+    cp_misaligned_store_page_fault_s:cross priv_mode_s, d_page_table_entry_bad, d_phys_address, sw;
+    cp_misaligned_inst_page_fault_s: cross priv_mode_s, i_page_table_entry_bad, i_phys_address, jalr;
     cp_instr_page_fault_u:           cross priv_mode_u, instr_page_fault;
     cp_load_page_fault_u:            cross priv_mode_u, load_page_fault;
     cp_store_page_fault_u:           cross priv_mode_u, store_page_fault;


### PR DESCRIPTION
**Changes in ExceptionsVM Zaamo & Zalrsc:**
I have removed `d_page_table_entry_bad` & `d_phys_address` from VMZaamo & VMZalrsc covergroups as they are not involved in any cross and are being covered in the main ExceptionVM covergroup.

**Changes in ExceptionsVM:**

`misaligned_pagespanning_address` is not required. It is rs1+imm which is actually our virtrual address. The last 12 bits of VA and PA are same. However, the cross is trying to check (rs1+imm = 12'b111111111110) with (phys_addr = 12'b111111111110 & 12'b0), which is not possible. I can add an ignore, but I think we don't need to check rs1+imm.

`cp_instr_page_fault_m, cp_misaligned_priority_fetch_m & cp_medeleg_fetch_m` are not possible as SUM does not affect instruction fetches. Instruction fetches always use physical address in M mode, and therefore we can't have PTEs and instr page faults while using physical address.

I have changed `jalr: coverpoint ins.current.insn` to `jalr: coverpoint ins.prev.insn`. Here is the log from a test I wrote for it.

Here, jalr is executed but pte, va & pa values are not yet right (see line beginning with -->)
```
# --> disass = 000780e7 jalr x1, 0(x15), inst = 000780e7, va = 00000300800015e0, phy_i = 000000800015e0, pte_i = 00000000000000cb
# Info 3816: 'refRoot/cpu', 0x00000300800015e0(main+de0): Supervisor 000780e7 jalr    x1,0(x15)

# Info   MEMX 0x300800015e0 0x800015e0 2 80e7
# Info   MEMX 0x300800015e2 0x800015e2 2 0007
# Info   x1 0000030080001324 -> 00000300800015e4
```
We perform page table walk, and get the correct values, but inst changes to 0000.
```
# --> disass = 0000 c.illegal, inst = 00000000, va = 0000040230044ffe, phy_i = 00000080005ffe, pte_i = 0000000020001400
# Info 3817: 'refRoot/cpu', 0x0000040230044ffe: Supervisor *** FETCH EXCEPTION ***
```
Our desired values appear when it tries to jump to the calculated PA, but inst changes to 0000. Therefore, we should use prev instead of current.





