### PR TITLE
Modified the PMPS and PMPU Coverpoints.

### DIFF
--- a/fcov/priv/PMPS_coverage.svh
+++ b/fcov/priv/PMPS_coverage.svh
@@ -199,6 +199,10 @@ covergroup PMPS_cg with function sample(ins_t ins, logic [16*XLEN-1:0] pack_pmpa
 		bins pmpcfg15  = {12'h3AF};
 	}
 
+	mode_switch: coverpoint ins.current.insn {
+		bins mret = {32'b00110000001000000000000001110011};
+	}
+
 	csrrw: coverpoint ins.current.insn {
 		wildcard bins csrrw  = {32'b????????????_?????_001_?????_1110011};
 	}
@@ -262,9 +266,7 @@ covergroup PMPS_cg with function sample(ins_t ins, logic [16*XLEN-1:0] pack_pmpa
 	cp_cfg_R: cross priv_mode_s, legal_lxwr, read_instr, standard_region, addr_in_region ;
 	cp_cfg_W: cross priv_mode_s, legal_lxwr, write_instr, standard_region, addr_in_region ;
 
-	cp_none_lw: cross priv_mode_s, all_pmp_entries_off, all_pmpaddr_zero, read_instr_lw ;
-	cp_none_sw: cross priv_mode_s, all_pmp_entries_off, all_pmpaddr_zero, write_instr_sw ;
-	cp_none_jalr: cross priv_mode_s, all_pmp_entries_off, all_pmpaddr_zero, exec_instr ;
+	cp_none: cross priv_mode_m, all_pmp_entries_off, all_pmpaddr_zero, mode_switch ;
 
 	cp_cfg_A_off_jalr: cross priv_mode_s, cfg_A_off, exec_instr, addr_in_region ;
 	cp_cfg_A_off_lw: cross priv_mode_s, cfg_A_off, read_instr_lw, addr_in_region ;

--- a/fcov/priv/PMPS_coverage.svh
+++ b/fcov/priv/PMPS_coverage.svh
@@ -207,7 +207,7 @@ covergroup PMPS_cg with function sample(ins_t ins, logic [16*XLEN-1:0] pack_pmpa
 		wildcard bins csrrw  = {32'b????????????_?????_001_?????_1110011};
 	}
 
-	mprv_mstatus: coverpoint ins.current.csr[12'h300][17]{
+	mprv_mstatus: coverpoint ins.prev.csr[12'h300][17]{
 		bins set   = {1};
 		bins unset = {0};
 	}
@@ -266,7 +266,7 @@ covergroup PMPS_cg with function sample(ins_t ins, logic [16*XLEN-1:0] pack_pmpa
 	cp_cfg_R: cross priv_mode_s, legal_lxwr, read_instr, standard_region, addr_in_region ;
 	cp_cfg_W: cross priv_mode_s, legal_lxwr, write_instr, standard_region, addr_in_region ;
 
-	cp_none: cross priv_mode_m, all_pmp_entries_off, all_pmpaddr_zero, mode_switch ;
+	cp_none: cross priv_mode_m, mpp_mstatus, all_pmp_entries_off, all_pmpaddr_zero, mode_switch ;
 
 	cp_cfg_A_off_jalr: cross priv_mode_s, cfg_A_off, exec_instr, addr_in_region ;
 	cp_cfg_A_off_lw: cross priv_mode_s, cfg_A_off, read_instr_lw, addr_in_region ;

--- a/fcov/priv/PMPS_coverage.svh
+++ b/fcov/priv/PMPS_coverage.svh
@@ -212,8 +212,9 @@ covergroup PMPS_cg with function sample(ins_t ins, logic [16*XLEN-1:0] pack_pmpa
 		bins unset = {0};
 	}
 
-	mpp_mstatus: coverpoint ins.current.csr[12'h300][12:11] {
+	mpp_mstatus: coverpoint ins.prev.csr[12'h300][12:11] {
 		bins S_mode = {2'b01};
+		bins M_Mode = {2'b11};
 	}
 
 	lxwr: coverpoint ins.current.csr[12'h3A0][7:0] {

--- a/fcov/priv/PMPS_coverage.svh
+++ b/fcov/priv/PMPS_coverage.svh
@@ -214,7 +214,6 @@ covergroup PMPS_cg with function sample(ins_t ins, logic [16*XLEN-1:0] pack_pmpa
 
 	mpp_mstatus: coverpoint ins.prev.csr[12'h300][12:11] {
 		bins S_mode = {2'b01};
-		bins M_Mode = {2'b11};
 	}
 
 	lxwr: coverpoint ins.current.csr[12'h3A0][7:0] {

--- a/fcov/priv/PMPU_coverage.svh
+++ b/fcov/priv/PMPU_coverage.svh
@@ -200,6 +200,10 @@ covergroup PMPU_cg with function sample(ins_t ins, logic [16*XLEN-1:0] pack_pmpa
 		bins pmpcfg15  = {12'h3AF};
 	}
 
+	mode_switch: coverpoint ins.current.insn {
+		bins mret = {32'b00110000001000000000000001110011};
+	}
+
 	csrrw: coverpoint ins.current.insn {
 		wildcard bins csrrw  = {32'b????????????_?????_001_?????_1110011};
 	}
@@ -264,9 +268,7 @@ covergroup PMPU_cg with function sample(ins_t ins, logic [16*XLEN-1:0] pack_pmpa
 	cp_cfg_R: cross priv_mode_u, legal_lxwr, read_instr, standard_region, addr_in_region ;
 	cp_cfg_W: cross priv_mode_u, legal_lxwr, write_instr, standard_region, addr_in_region ;
 
-	cp_none_lw: cross priv_mode_u, all_pmp_entries_off, all_pmpaddr_zero, read_instr_lw ;
-	cp_none_sw: cross priv_mode_u, all_pmp_entries_off, all_pmpaddr_zero, write_instr_sw ;
-	cp_none_jalr: cross priv_mode_u, all_pmp_entries_off, all_pmpaddr_zero, exec_instr ;
+	cp_none: cross priv_mode_m, all_pmp_entries_off, all_pmpaddr_zero, mode_switch ;
 
 	cp_cfg_A_off_jalr: cross priv_mode_u, cfg_A_off, exec_instr, addr_in_region ;
 	cp_cfg_A_off_lw: cross priv_mode_u, cfg_A_off, read_instr_lw, addr_in_region ;

--- a/fcov/priv/PMPU_coverage.svh
+++ b/fcov/priv/PMPU_coverage.svh
@@ -213,9 +213,8 @@ covergroup PMPU_cg with function sample(ins_t ins, logic [16*XLEN-1:0] pack_pmpa
 		bins unset = {0};
 	}
 
-	mpp_mstatus: coverpoint ins.current.csr[12'h300][12:11] {
+	mpp_mstatus: coverpoint ins.prev.csr[12'h300][12:11] {
 		bins U_mode = {2'b00};
-		bins M_mode = {2'b11};
 	}
 
 	lxwr: coverpoint ins.current.csr[12'h3A0][7:0] {

--- a/fcov/priv/PMPU_coverage.svh
+++ b/fcov/priv/PMPU_coverage.svh
@@ -208,7 +208,7 @@ covergroup PMPU_cg with function sample(ins_t ins, logic [16*XLEN-1:0] pack_pmpa
 		wildcard bins csrrw  = {32'b????????????_?????_001_?????_1110011};
 	}
 
-	mprv_mstatus: coverpoint ins.current.csr[12'h300][17]{
+	mprv_mstatus: coverpoint ins.prev.csr[12'h300][17]{
 		bins set   = {1};
 		bins unset = {0};
 	}
@@ -267,7 +267,7 @@ covergroup PMPU_cg with function sample(ins_t ins, logic [16*XLEN-1:0] pack_pmpa
 	cp_cfg_R: cross priv_mode_u, legal_lxwr, read_instr, standard_region, addr_in_region ;
 	cp_cfg_W: cross priv_mode_u, legal_lxwr, write_instr, standard_region, addr_in_region ;
 
-	cp_none: cross priv_mode_m, all_pmp_entries_off, all_pmpaddr_zero, mode_switch ;
+	cp_none: cross priv_mode_m, mpp_mstatus, all_pmp_entries_off, all_pmpaddr_zero, mode_switch ;
 
 	cp_cfg_A_off_jalr: cross priv_mode_u, cfg_A_off, exec_instr, addr_in_region ;
 	cp_cfg_A_off_lw: cross priv_mode_u, cfg_A_off, read_instr_lw, addr_in_region ;


### PR DESCRIPTION
```
 TYPE /RISCV_coverage_pkg/RISCV_coverage__1/PMPU_cg 
                                                      100.00%        100          -    Covered              
    covered/total bins:                                   579        579          -                      
    missing/total bins:                                     0        579          -                      
    % Hit:                                            100.00%        100          -             
```

```
 TYPE /RISCV_coverage_pkg/RISCV_coverage__1/PMPS_cg 
                                                      100.00%        100          -    Covered              
    covered/total bins:                                   579        579          -                      
    missing/total bins:                                     0        579          -                      
    % Hit:                                            100.00%        100          -             
```