### PR TITLE
Modified existing CBO_VM coverpoints & added new ones as well

### DIFF
--- a/fcov/rv32_priv/RV32CBO_VM_coverage.svh
+++ b/fcov/rv32_priv/RV32CBO_VM_coverage.svh
@@ -70,6 +70,16 @@ covergroup RV32CBO_VM_exceptions_cg with function sample(ins_t ins);
         wildcard bins leaflvl_s = {8'b???01111};
     }
 
+    pointer_PTE_d: coverpoint ins.current.pte_d[7:0] {
+        wildcard bins pointer = {8'b00?00001};
+    }
+
+    PTE_DAU_d: coverpoint ins.current.pte_d[7:0] {
+        wildcard bins nonleaf_D_bit = {8'b1?0?0001};
+        wildcard bins nonleaf_A_bit = {8'b?10?0001};
+        wildcard bins nonleaf_U_bit = {8'b??010001};
+    }
+
     //PageType && misaligned PPN for DTLB to ensure that leaf pte is found at all levels (through crosses of PTE and PPN)
 
     PageType_d: coverpoint ins.current.page_type_d {
@@ -86,79 +96,100 @@ covergroup RV32CBO_VM_exceptions_cg with function sample(ins_t ins);
         bins sv32   = {1'b1};
     }
 
-    //For crosses with write accesses and its corresponding faults
-    write_acc: coverpoint ins.current.write_access{
-        bins set = {1};
-    }
-    Mcause: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
+    store_page_fault: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
         bins store_amo_page_fault = {64'd15};
+    }
+    store_acc_fault: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
+        bins store_amo_access_fault = {64'd7};
     }
     sum_sstatus: coverpoint ins.current.csr[12'h100][18]{
         bins notset = {0};
         bins set = {1};
+    }
+    d_phys_address_nonexistant: coverpoint ({ins.current.phys_adr_d[33:2], 2'b00} == `ACCESS_FAULT_ADDRESS) {
+        bins non_existant_pa = {1};
     }
 
     cbo_ins: coverpoint ins.current.insn {
         wildcard bins any_cbo_ins = {32'b000000000000_?????_010_00000_0001111, 32'b000000000001_?????_010_00000_0001111, 32'b000000000010_?????_010_00000_0001111};
     }
 
-    PTE_inv_write_s_d: cross PTE_d_inv, PageType_d, mode, Mcause, write_acc, cbo_ins  { //exp.2
+    PTE_inv_write_s_d: cross PTE_d_inv, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s  { //exp.2
         ignore_bins ig1 = binsof(PTE_d_inv.leaflvl_u_w);
     }
-    PTE_inv_write_u_d: cross PTE_d_inv, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.2
+    PTE_inv_write_u_d: cross PTE_d_inv, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u { //exp.2
         ignore_bins ig1 = binsof(PTE_d_inv.leaflvl_s_w);
     }
 
-    PTE_res_rwx_s_d_write: cross PTE_d_res_rwx, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.2
+    PTE_res_rwx_s_d_write: cross PTE_d_res_rwx, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s { //exp.2
         ignore_bins ig1 = binsof(PTE_d_res_rwx.leaflvl_exec_u);
         ignore_bins ig2 = binsof(PTE_d_res_rwx.leaflvl_noexec_u);
     }
-    PTE_res_rwx_u_d_write: cross PTE_d_res_rwx, PageType_d, mode, Mcause, write_acc, cbo_ins  { //exp.2
+    PTE_res_rwx_u_d_write: cross PTE_d_res_rwx, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u  { //exp.2
         ignore_bins ig1 = binsof(PTE_d_res_rwx.leaflvl_exec_s);
         ignore_bins ig2 = binsof(PTE_d_res_rwx.leaflvl_noexec_s);
     }
 
-    PTE_nonleaf_lvl0_s_d_write: cross PTE_nonleaf_lvl0_d, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.3
+    PTE_nonleaf_lvl0_s_d_write: cross PTE_nonleaf_lvl0_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s { //exp.3
         ignore_bins ig1 = binsof(PTE_nonleaf_lvl0_d.lvl0_u);
     }
 
-    PTE_nonleaf_lvl0_u_d_write: cross PTE_nonleaf_lvl0_d, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.3
+    PTE_nonleaf_lvl0_u_d_write: cross PTE_nonleaf_lvl0_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u { //exp.3
         ignore_bins ig1 = binsof(PTE_nonleaf_lvl0_d.lvl0_s);
     }
 
-    spage_nowrite_s_d: cross PTE_rw_spage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_s, sum_sstatus { //exp.4 & 5
+    spage_nowrite_s_d: cross PTE_rw_spage_d, PageType_d, mode, cbo_ins, priv_mode_s, sum_sstatus, priv_mode_s { //exp.4 & 5
     }
 
-    spage_rwx_s_d_nowrite: cross PTE_spage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_u { //exp.6
+    spage_rwx_s_d_nowrite: cross PTE_spage_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u { //exp.6
     }
 
-    upage_smode_sumunset_nowrite_s: cross PTE_upage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_s, sum_sstatus { //exp.7
+    upage_smode_sumunset_nowrite_s: cross PTE_upage_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s, sum_sstatus { //exp.7
         ignore_bins ig1 = binsof(sum_sstatus.set);
     }
 
-    upage_umode_nowrite_u: cross PTE_rw_upage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_u { //exp.8
+    upage_umode_nowrite_u: cross PTE_rw_upage_d, PageType_d, mode, cbo_ins, priv_mode_u { //exp.8
     }
 
-    Abit_unset_write_s: cross PTE_Abit_unset_d, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.9
+    Abit_unset_write_s: cross PTE_Abit_unset_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s { //exp.9
         ignore_bins ig1 = binsof(PTE_Abit_unset_d.leaflvl_u);
     }
-    Abit_unset_write_u: cross PTE_Abit_unset_d, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.9
+    Abit_unset_write_u: cross PTE_Abit_unset_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u { //exp.9
         ignore_bins ig1 = binsof(PTE_Abit_unset_d.leaflvl_s);
     }
 
-    Dbit_set_w_write_s: cross PTE_Dbit_set_W_d, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.10
+    Dbit_set_w_write_s: cross PTE_Dbit_set_W_d, PageType_d, mode, cbo_ins, priv_mode_s { //exp.10
         ignore_bins ig1 = binsof(PTE_Dbit_set_W_d.leaflvl_u);
     }
-    Dbit_set_w_write_u: cross PTE_Dbit_set_W_d, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.10
+    Dbit_set_w_write_u: cross PTE_Dbit_set_W_d, PageType_d, mode, cbo_ins, priv_mode_u { //exp.10
         ignore_bins ig1 = binsof(PTE_Dbit_set_W_d.leaflvl_s);
     }
 
-    misaligned_write_s: cross PTE_RWX_d, misaligned_PPN_d, mode, Mcause, write_acc, cbo_ins  { //exp.11
+    misaligned_write_s: cross PTE_RWX_d, misaligned_PPN_d, mode, store_page_fault, cbo_ins, priv_mode_s  { //exp.11
         ignore_bins ig1 = binsof(PTE_RWX_d.leaflvl_u);
     }
-    misaligned_write_u: cross PTE_RWX_d, misaligned_PPN_d, mode, Mcause, write_acc, cbo_ins  { //exp.11
+    misaligned_write_u: cross PTE_RWX_d, misaligned_PPN_d, mode, store_page_fault, cbo_ins, priv_mode_u  { //exp.11
         ignore_bins ig1 = binsof(PTE_RWX_d.leaflvl_s);
     }
+
+    // PTE points to a non existant physical address
+    leaf_PTE_to_nonexistant_pa_s: cross PTE_RWX_d, d_phys_address_nonexistant, PageType_d, mode, store_acc_fault, cbo_ins, priv_mode_s {
+        ignore_bins ig1 = binsof(PTE_RWX_d.leaflvl_u);
+    }
+    leaf_PTE_to_nonexistant_pa_u: cross PTE_RWX_d, d_phys_address_nonexistant, PageType_d, mode, store_acc_fault, cbo_ins, priv_mode_u {
+        ignore_bins ig1 = binsof(PTE_RWX_d.leaflvl_s);
+    }
+
+    // Non leaf PTE points to a non existatant phys addr instead of next page table. Store access fault required during walk
+    // Example: Setup a level 0 page in sv48, lvl 1 pte should point to lvl0 page table, but it points to non existant PA
+    nonleaf_PTE_to_nonexistant_pa: cross pointer_PTE_d, d_phys_address_nonexistant, PageType_d, mode, store_acc_fault, cbo_ins, priv_mode_su {
+        ignore_bins ig1 = binsof(PageType_d.mega);                          // Here PageType_d will be the type being pointed towards
+    }
+
+    PTE_nonleaf_DAU: cross PTE_DAU_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_su {
+        ignore_bins ig1 = binsof(PageType_d.kilo);
+    }
+
 endgroup
 
 function void rv32cbo_vm_sample(int hart, int issue, ins_t ins);

--- a/fcov/rv64_priv/RV64CBO_VM_coverage.svh
+++ b/fcov/rv64_priv/RV64CBO_VM_coverage.svh
@@ -17,6 +17,7 @@
 // either express or implied. See the License for the specific language governing permissions
 // and limitations under the License.
 ////////////////////////////////////////////////////////////////////////////////////////////////
+`define sv48
 `define COVER_RV64CBO_VM
 covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
     option.per_instance = 0;
@@ -70,6 +71,16 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
         wildcard bins leaflvl_s = {8'b???01111};
     }
 
+    pointer_PTE_d: coverpoint ins.current.pte_d[7:0] {
+        wildcard bins pointer = {8'b00?00001};
+    }
+
+    PTE_DAU_d: coverpoint ins.current.pte_d[7:0] {
+        wildcard bins nonleaf_D_bit = {8'b1?0?0001};
+        wildcard bins nonleaf_A_bit = {8'b?10?0001};
+        wildcard bins nonleaf_U_bit = {8'b??010001};
+    }
+
     //PageType && misaligned PPN for DTLB to ensure that leaf pte is found at all levels (through crosses of PTE and PPN)
 
     PageType_d: coverpoint ins.current.page_type_d {
@@ -81,12 +92,12 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
         bins kilo = {2'd0};
     }
 
-    misaligned_PPN_d: coverpoint ins.current.ppn_d[26:0] {
+    misaligned_PPN_d: coverpoint check_misalignment(ins.current.ppn_d[26:0], ins.current.page_type_d) {
         `ifdef sv48
-            bins tera_not_zero = {[27'd1:27'd134217727]};
+            wildcard bins tera_not_zero = {3'b100};
         `endif
-        bins giga_not_zero = {[18'd1:18'd262143]};
-        bins mega_not_zero = {[9'd1:9'd511]};
+        wildcard bins giga_not_zero = {3'b010};
+        wildcard bins mega_not_zero = {3'b001};
     }
 
     //satp.mode for coverage of both sv39 and sv48
@@ -99,39 +110,45 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
         `endif
     }
 
-    //For crosses with write accesses and its corresponding faults
-    write_acc: coverpoint ins.current.write_access{
-        bins set = {1};
-    }
-    Mcause: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
+    store_page_fault: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
         bins store_amo_page_fault = {64'd15};
+    }
+    store_acc_fault: coverpoint  ins.current.csr[12'h342] iff (ins.trap == 1) {
+        bins store_amo_access_fault = {64'd7};
     }
     sum_sstatus: coverpoint ins.current.csr[12'h100][18]{
         bins notset = {0};
         bins set = {1};
+    }
+    d_phys_address_nonexistant: coverpoint ({ins.current.phys_adr_d[55:2], 2'b00} == `ACCESS_FAULT_ADDRESS) {
+        bins non_existant_pa = {1};
     }
 
     cbo_ins: coverpoint ins.current.insn {
         wildcard bins any_cbo_ins = {32'b000000000000_?????_010_00000_0001111, 32'b000000000001_?????_010_00000_0001111, 32'b000000000010_?????_010_00000_0001111};
     }
 
-    PTE_inv_write_s_d: cross PTE_d_inv, PageType_d, mode, Mcause, write_acc, cbo_ins  { //exp.2
+    PTE_inv_write_s_d: cross PTE_d_inv, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s { //exp.2
         ignore_bins ig1 = binsof(PTE_d_inv.leaflvl_u_w);
+        ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
-    PTE_inv_write_u_d: cross PTE_d_inv, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.2
+    PTE_inv_write_u_d: cross PTE_d_inv, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u { //exp.2
         ignore_bins ig1 = binsof(PTE_d_inv.leaflvl_s_w);
+        ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    PTE_res_rwx_s_d_write: cross PTE_d_res_rwx, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.2
+    PTE_res_rwx_s_d_write: cross PTE_d_res_rwx, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s { //exp.2
         ignore_bins ig1 = binsof(PTE_d_res_rwx.leaflvl_exec_u);
         ignore_bins ig2 = binsof(PTE_d_res_rwx.leaflvl_noexec_u);
+        ignore_bins ig3 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
-    PTE_res_rwx_u_d_write: cross PTE_d_res_rwx, PageType_d, mode, Mcause, write_acc, cbo_ins  { //exp.2
+    PTE_res_rwx_u_d_write: cross PTE_d_res_rwx, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u  { //exp.2
         ignore_bins ig1 = binsof(PTE_d_res_rwx.leaflvl_exec_s);
         ignore_bins ig2 = binsof(PTE_d_res_rwx.leaflvl_noexec_s);
+        ignore_bins ig3 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    PTE_nonleaf_lvl0_s_d_write: cross PTE_nonleaf_lvl0_d, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.3
+    PTE_nonleaf_lvl0_s_d_write: cross PTE_nonleaf_lvl0_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s { //exp.3
         ignore_bins ig1 = binsof(PTE_nonleaf_lvl0_d.lvl0_u);
         ignore_bins ig2 = binsof(PageType_d.giga);
         ignore_bins ig3 = binsof(PageType_d.mega);
@@ -140,7 +157,7 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
         `endif
     }
 
-    PTE_nonleaf_lvl0_u_d_write: cross PTE_nonleaf_lvl0_d, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.3
+    PTE_nonleaf_lvl0_u_d_write: cross PTE_nonleaf_lvl0_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u { //exp.3
         ignore_bins ig1 = binsof(PTE_nonleaf_lvl0_d.lvl0_s);
         ignore_bins ig2 = binsof(PageType_d.giga);
         ignore_bins ig3 = binsof(PageType_d.mega);
@@ -149,39 +166,72 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
         `endif
     }
 
-    spage_nowrite_s_d: cross PTE_rw_spage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_s, sum_sstatus { //exp.4 & 5
+    spage_nowrite_s_d: cross PTE_rw_spage_d, PageType_d, mode, cbo_ins, priv_mode_s, sum_sstatus, priv_mode_s { //exp.4 & 5
+        ignore_bins ig1 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    spage_rwx_s_d_nowrite: cross PTE_spage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_u { //exp.6
+    spage_rwx_s_d_nowrite: cross PTE_spage_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u { //exp.6
+        ignore_bins ig1 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    upage_smode_sumunset_nowrite_s: cross PTE_upage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_s, sum_sstatus { //exp.7
+    upage_smode_sumunset_nowrite_s: cross PTE_upage_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s, sum_sstatus { //exp.7
         ignore_bins ig1 = binsof(sum_sstatus.set);
+        ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    upage_umode_nowrite_u: cross PTE_rw_upage_d, PageType_d, mode, Mcause, write_acc, cbo_ins, priv_mode_u { //exp.8
+    upage_umode_nowrite_u: cross PTE_rw_upage_d, PageType_d, mode, cbo_ins, priv_mode_u { //exp.8
+        ignore_bins ig1 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    Abit_unset_write_s: cross PTE_Abit_unset_d, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.9
+    Abit_unset_write_s: cross PTE_Abit_unset_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s { //exp.9
         ignore_bins ig1 = binsof(PTE_Abit_unset_d.leaflvl_u);
+        ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
-    Abit_unset_write_u: cross PTE_Abit_unset_d, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.9
+    Abit_unset_write_u: cross PTE_Abit_unset_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u { //exp.9
         ignore_bins ig1 = binsof(PTE_Abit_unset_d.leaflvl_s);
+        ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    Dbit_set_w_write_s: cross PTE_Dbit_set_W_d, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.10
+    Dbit_set_w_write_s: cross PTE_Dbit_set_W_d, PageType_d, mode, cbo_ins, priv_mode_s { //exp.10
         ignore_bins ig1 = binsof(PTE_Dbit_set_W_d.leaflvl_u);
+        ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
-    Dbit_set_w_write_u: cross PTE_Dbit_set_W_d, PageType_d, mode, Mcause, write_acc, cbo_ins { //exp.10
+    Dbit_set_w_write_u: cross PTE_Dbit_set_W_d, PageType_d, mode, cbo_ins, priv_mode_u { //exp.10
         ignore_bins ig1 = binsof(PTE_Dbit_set_W_d.leaflvl_s);
+        ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    misaligned_write_s: cross PTE_RWX_d, misaligned_PPN_d, mode, Mcause, write_acc, cbo_ins  { //exp.11
+    misaligned_write_s: cross PTE_RWX_d, misaligned_PPN_d, mode, store_page_fault, cbo_ins, priv_mode_s  { //exp.11
         ignore_bins ig1 = binsof(PTE_RWX_d.leaflvl_u);
+        ignore_bins ig2 = binsof(mode.sv39) && binsof(misaligned_PPN_d.tera_not_zero);
     }
-    misaligned_write_u: cross PTE_RWX_d, misaligned_PPN_d, mode, Mcause, write_acc, cbo_ins  { //exp.11
+    misaligned_write_u: cross PTE_RWX_d, misaligned_PPN_d, mode, store_page_fault, cbo_ins, priv_mode_u  { //exp.11
         ignore_bins ig1 = binsof(PTE_RWX_d.leaflvl_s);
+        ignore_bins ig2 = binsof(mode.sv39) && binsof(misaligned_PPN_d.tera_not_zero);
     }
+
+    // PTE points to a non existant physical address
+    leaf_PTE_to_nonexistant_pa_s: cross PTE_RWX_d, d_phys_address_nonexistant, PageType_d, mode, store_acc_fault, cbo_ins, priv_mode_s {
+        ignore_bins ig1 = binsof(PTE_RWX_d.leaflvl_u);
+        ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
+    }
+    leaf_PTE_to_nonexistant_pa_u: cross PTE_RWX_d, d_phys_address_nonexistant, PageType_d, mode, store_acc_fault, cbo_ins, priv_mode_u {
+        ignore_bins ig1 = binsof(PTE_RWX_d.leaflvl_s);
+        ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
+    }
+
+    // Non leaf PTE points to a non existatant phys addr instead of next page table. Store access fault required during walk
+    // Example: Setup a giga page in sv48, lvl 3 pte (tera) should point to lvl2 page table, but it points to non existant PA
+    nonleaf_PTE_to_nonexistant_pa: cross pointer_PTE_d, d_phys_address_nonexistant, PageType_d, mode, store_acc_fault, cbo_ins, priv_mode_su {
+        ignore_bins ig1 = binsof(PageType_d.tera);                          // Here PageType_d will be the type being pointed towards
+        ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.giga);
+    }
+
+    PTE_nonleaf_DAU: cross PTE_DAU_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_su {
+        ignore_bins ig1 = binsof(PageType_d.kilo);
+        ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
+    }
+
 endgroup
 
 function void rv64cbo_vm_sample(int hart, int issue, ins_t ins);

--- a/fcov/rv64_priv/RV64CBO_VM_coverage.svh
+++ b/fcov/rv64_priv/RV64CBO_VM_coverage.svh
@@ -17,7 +17,9 @@
 // either express or implied. See the License for the specific language governing permissions
 // and limitations under the License.
 ////////////////////////////////////////////////////////////////////////////////////////////////
+
 `define sv48
+`define sv39
 `define COVER_RV64CBO_VM
 covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
     option.per_instance = 0;


### PR DESCRIPTION
I have added some new coverpoints which check for store access faults. Therefore, I have removed Mcause coverpoint and made 2 separate coverpoints for store page fault and store access fault.
I have also added coverpoints to check for DAU faults for non leaf PTEs when zicbom instructions are executed. 

**Modifications to existing coverpoints:**
I have removed **write_acc** because it does not tell us that a cbo instruction is being executed. Even in RTL, CMOpM is used instead of WriteAccess. 
Coverpoints for misaligned_PPN were incorrect. I have made the same change that I made for RV64VM misaligned coverpoint. 

Coverpoints **spage_nowrite_s_d** and **upage_umode_nowrite_u** were wrong. It was checking for store page faults when W=0 (same is written in the test plan). But Zicbom instructions do not depend upon W permission. As mentioned in section 19.4.2.2 of Unpriv Spec
```
A cache-block management instruction is permitted to access the specified cache block whenever a
load instruction or store instruction is permitted to access the corresponding physical addresses.
```
Therefore, as we have R=1, it won't fault. Either we can use this test case to confirm that cbo doesn't fault when W=0 and R=1. Or we could update the coverpoint to check for fault when R=0 and W=0.

Similarly, it won't fault when D=0. In the same section of spec we have,

```
During address translation, the instruction also checks the accessed bit and may either
raise an exception or set the bit as required.
```
```
As implied by omission, a cache-block management instruction does not check the
dirty bit and neither raises an exception nor sets the bit.
```

The **testplan** also needs to be updated accordingly.
