### PR TITLE
Added Zicboz coverpoints to VM_CBO

### DIFF
--- a/fcov/rv64_priv/RV64CBO_VM_coverage.svh
+++ b/fcov/rv64_priv/RV64CBO_VM_coverage.svh
@@ -26,15 +26,15 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
     `include  "coverage/RISCV_coverage_standard_coverpoints.svh"
     //pte permission for leaf PTEs
     PTE_d_inv: coverpoint ins.current.pte_d[7:0] {
-        wildcard bins leaflvl_u_w = {8'b???1?110};
-        wildcard bins leaflvl_s_w = {8'b???0?110};
+        wildcard bins leaflvl_u_w = {8'b11?1?110};
+        wildcard bins leaflvl_s_w = {8'b11?0?110};
     }
 
     PTE_d_res_rwx: coverpoint ins.current.pte_d[7:0] {
-        wildcard bins leaflvl_exec_u = {8'b???11101};
-        wildcard bins leaflvl_noexec_u = {8'b???10101};
-        wildcard bins leaflvl_exec_s = {8'b???01101};
-        wildcard bins leaflvl_noexec_s = {8'b???00101};
+        wildcard bins leaflvl_exec_u = {8'b11?11101};
+        wildcard bins leaflvl_noexec_u = {8'b11?10101};
+        wildcard bins leaflvl_exec_s = {8'b11?01101};
+        wildcard bins leaflvl_noexec_s = {8'b11?00101};
     }
 
     PTE_nonleaf_lvl0_d: coverpoint ins.current.pte_d[7:0] {
@@ -43,35 +43,35 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
     }
 
     PTE_r_set_w_unset_spage_d: coverpoint ins.current.pte_d[7:0] {
-        wildcard bins leaflvl_r_s = {8'b???0?011};
+        wildcard bins leaflvl_r_s = {8'b11?0?011};
     }
 
     PTE_w_unset_spage_d: coverpoint ins.current.pte_d[7:0] {
-        wildcard bins leaflvl_w_0 = {8'b???0?0?1};
+        wildcard bins leaflvl_w_0 = {8'b11?0?0?1};
     }
 
     PTE_x_spage_d: coverpoint ins.current.pte_d[7:0] {
-        wildcard bins leaflvl_x_s = {8'b???01001};
+        wildcard bins leaflvl_x_s = {8'b11?01001};
     }
 
     PTE_spage_d: coverpoint ins.current.pte_d[7:0] {
-        wildcard bins leaflvl_s = {8'b???01111};
+        wildcard bins leaflvl_s = {8'b11?01111};
     }
 
     PTE_upage_d: coverpoint ins.current.pte_d[7:0] {
-        wildcard bins leaflvl_u = {8'b???11111};
+        wildcard bins leaflvl_u = {8'b11?11111};
     }
 
     PTE_r_set_w_unset_upage_d: coverpoint ins.current.pte_d[7:0] {
-        wildcard bins leaflvl_r_u = {8'b???1?011};
+        wildcard bins leaflvl_r_u = {8'b11?1?011};
     }
 
     PTE_w_unset_upage_d: coverpoint ins.current.pte_d[7:0] {
-        wildcard bins leaflvl_w_0 = {8'b???1?0?1};
+        wildcard bins leaflvl_w_0 = {8'b11?1?0?1};
     }
 
     PTE_x_upage_d: coverpoint ins.current.pte_d[7:0] {
-        wildcard bins leaflvl_x_u = {8'b???11001};
+        wildcard bins leaflvl_x_u = {8'b11?11001};
     }
 
     PTE_Abit_unset_d: coverpoint ins.current.pte_d[7:0] {
@@ -85,8 +85,8 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
     }
 
     PTE_RWX_d: coverpoint ins.current.pte_d[7:0] {
-        wildcard bins leaflvl_u = {8'b???11111};
-        wildcard bins leaflvl_s = {8'b???01111};
+        wildcard bins leaflvl_u = {8'b11?11111};
+        wildcard bins leaflvl_s = {8'b11?01111};
     }
 
     pointer_PTE_d: coverpoint ins.current.pte_d[7:0] {

--- a/fcov/rv64_priv/RV64CBO_VM_coverage.svh
+++ b/fcov/rv64_priv/RV64CBO_VM_coverage.svh
@@ -42,8 +42,12 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
         wildcard bins lvl0_u = {8'b???10001};
     }
 
-    PTE_rw_spage_d: coverpoint ins.current.pte_d[7:0] {
-        wildcard bins leaflvl_w_0 = {8'b???0?0?1};
+    PTE_r_spage_d: coverpoint ins.current.pte_d[7:0] {
+        wildcard bins leaflvl_w_0 = {8'b???0?011};
+    }
+
+    PTE_x_spage_d: coverpoint ins.current.pte_d[7:0] {
+        wildcard bins leaflvl_x_s = {8'b???01001};
     }
 
     PTE_spage_d: coverpoint ins.current.pte_d[7:0] {
@@ -54,8 +58,12 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
         wildcard bins leaflvl_u = {8'b???11111};
     }
 
-    PTE_rw_upage_d: coverpoint ins.current.pte_d[7:0] {
-        wildcard bins leaflvl_w_0 = {8'b???1?0?1};
+    PTE_r_upage_d: coverpoint ins.current.pte_d[7:0] {
+        wildcard bins leaflvl_w_0 = {8'b???1?011};
+    }
+
+    PTE_x_upage_d: coverpoint ins.current.pte_d[7:0] {
+        wildcard bins leaflvl_x_u = {8'b???11001};
     }
 
     PTE_Abit_unset_d: coverpoint ins.current.pte_d[7:0] {
@@ -168,7 +176,7 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
         `endif
     }
 
-    spage_nowrite_s_d: cross PTE_rw_spage_d, PageType_d, mode, cbo_ins, priv_mode_s, sum_sstatus, priv_mode_s {
+    PTE_w_unset_s_d: cross PTE_r_spage_d, PageType_d, mode, cbo_ins, priv_mode_s, sum_sstatus {
         ignore_bins ig1 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
@@ -181,7 +189,15 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
         ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    upage_umode_nowrite_u: cross PTE_rw_upage_d, PageType_d, mode, cbo_ins, priv_mode_u {
+    PTE_w_unset_u_d: cross PTE_r_upage_d, PageType_d, mode, cbo_ins, priv_mode_u {
+        ignore_bins ig1 = binsof(mode.sv39) && binsof(PageType_d.tera);
+    }
+
+    PTE_rw_unset_s_d: cross PTE_x_spage_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s {
+        ignore_bins ig1 = binsof(mode.sv39) && binsof(PageType_d.tera);
+    }
+
+    PTE_rw_unset_u_d: cross PTE_x_upage_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u {
         ignore_bins ig1 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 

--- a/fcov/rv64_priv/RV64CBO_VM_coverage.svh
+++ b/fcov/rv64_priv/RV64CBO_VM_coverage.svh
@@ -71,7 +71,7 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
         wildcard bins leaflvl_s = {8'b?0?01111};
     }
 
-    PTE_Dbit_set_W_d: coverpoint ins.current.pte_d[7:0] {
+    PTE_Dbit_unset_d: coverpoint ins.current.pte_d[7:0] {
         wildcard bins leaflvl_u = {8'b01?1?111};
         wildcard bins leaflvl_s = {8'b01?0?111};
     }
@@ -138,27 +138,27 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
         wildcard bins any_cbo_ins = {32'b000000000000_?????_010_00000_0001111, 32'b000000000001_?????_010_00000_0001111, 32'b000000000010_?????_010_00000_0001111};
     }
 
-    PTE_inv_write_s_d: cross PTE_d_inv, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s {
+    PTE_inv_cbo_s: cross PTE_d_inv, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s {
         ignore_bins ig1 = binsof(PTE_d_inv.leaflvl_u_w);
         ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
-    PTE_inv_write_u_d: cross PTE_d_inv, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u {
+    PTE_inv_cbo_u: cross PTE_d_inv, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u {
         ignore_bins ig1 = binsof(PTE_d_inv.leaflvl_s_w);
         ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    PTE_res_rwx_s_d_write: cross PTE_d_res_rwx, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s {
+    PTE_res_rwx_cbo_s: cross PTE_d_res_rwx, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s {
         ignore_bins ig1 = binsof(PTE_d_res_rwx.leaflvl_exec_u);
         ignore_bins ig2 = binsof(PTE_d_res_rwx.leaflvl_noexec_u);
         ignore_bins ig3 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
-    PTE_res_rwx_u_d_write: cross PTE_d_res_rwx, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u  {
+    PTE_res_rwx_cbo_u: cross PTE_d_res_rwx, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u  {
         ignore_bins ig1 = binsof(PTE_d_res_rwx.leaflvl_exec_s);
         ignore_bins ig2 = binsof(PTE_d_res_rwx.leaflvl_noexec_s);
         ignore_bins ig3 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    PTE_nonleaf_lvl0_s_d_write: cross PTE_nonleaf_lvl0_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s {
+    PTE_nonleaf_lvl0_cbo_s: cross PTE_nonleaf_lvl0_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s {
         ignore_bins ig1 = binsof(PTE_nonleaf_lvl0_d.lvl0_u);
         ignore_bins ig2 = binsof(PageType_d.giga);
         ignore_bins ig3 = binsof(PageType_d.mega);
@@ -167,7 +167,7 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
         `endif
     }
 
-    PTE_nonleaf_lvl0_u_d_write: cross PTE_nonleaf_lvl0_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u {
+    PTE_nonleaf_lvl0_cbo_u: cross PTE_nonleaf_lvl0_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u {
         ignore_bins ig1 = binsof(PTE_nonleaf_lvl0_d.lvl0_s);
         ignore_bins ig2 = binsof(PageType_d.giga);
         ignore_bins ig3 = binsof(PageType_d.mega);
@@ -176,76 +176,76 @@ covergroup RV64CBO_VM_exceptions_cg with function sample(ins_t ins);
         `endif
     }
 
-    PTE_w_unset_s_d: cross PTE_r_spage_d, PageType_d, mode, cbo_ins, priv_mode_s, sum_sstatus {
+    PTE_w_unset_cbo_s: cross PTE_r_spage_d, PageType_d, mode, cbo_ins, priv_mode_s, sum_sstatus {
         ignore_bins ig1 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    spage_rwx_s_d_nowrite: cross PTE_spage_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u {
+    spage_rwx_cbo_s: cross PTE_spage_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u {
         ignore_bins ig1 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    upage_smode_sumunset_nowrite_s: cross PTE_upage_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s, sum_sstatus {
+    upage_smode_sumunset_cbo_s: cross PTE_upage_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s, sum_sstatus {
         ignore_bins ig1 = binsof(sum_sstatus.set);
         ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    PTE_w_unset_u_d: cross PTE_r_upage_d, PageType_d, mode, cbo_ins, priv_mode_u {
+    PTE_w_unset_cbo_u: cross PTE_r_upage_d, PageType_d, mode, cbo_ins, priv_mode_u {
         ignore_bins ig1 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    PTE_rw_unset_s_d: cross PTE_x_spage_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s {
+    PTE_rw_unset_cbo_s: cross PTE_x_spage_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s {
         ignore_bins ig1 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    PTE_rw_unset_u_d: cross PTE_x_upage_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u {
+    PTE_rw_unset_cbo_u: cross PTE_x_upage_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u {
         ignore_bins ig1 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    Abit_unset_write_s: cross PTE_Abit_unset_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s {
+    Abit_unset_cbo_s: cross PTE_Abit_unset_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_s {
         ignore_bins ig1 = binsof(PTE_Abit_unset_d.leaflvl_u);
         ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
-    Abit_unset_write_u: cross PTE_Abit_unset_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u {
+    Abit_unset_cbo_u: cross PTE_Abit_unset_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_u {
         ignore_bins ig1 = binsof(PTE_Abit_unset_d.leaflvl_s);
         ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    Dbit_set_w_write_s: cross PTE_Dbit_set_W_d, PageType_d, mode, cbo_ins, priv_mode_s {
-        ignore_bins ig1 = binsof(PTE_Dbit_set_W_d.leaflvl_u);
+    Dbit_unset_cbo_s: cross PTE_Dbit_unset_d, PageType_d, mode, cbo_ins, priv_mode_s {
+        ignore_bins ig1 = binsof(PTE_Dbit_unset_d.leaflvl_u);
         ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
-    Dbit_set_w_write_u: cross PTE_Dbit_set_W_d, PageType_d, mode, cbo_ins, priv_mode_u {
-        ignore_bins ig1 = binsof(PTE_Dbit_set_W_d.leaflvl_s);
+    Dbit_unset_cbo_u: cross PTE_Dbit_unset_d, PageType_d, mode, cbo_ins, priv_mode_u {
+        ignore_bins ig1 = binsof(PTE_Dbit_unset_d.leaflvl_s);
         ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
-    misaligned_write_s: cross PTE_RWX_d, misaligned_PPN_d, mode, store_page_fault, cbo_ins, priv_mode_s  {
+    misaligned_page_cbo_s: cross PTE_RWX_d, misaligned_PPN_d, mode, store_page_fault, cbo_ins, priv_mode_s  {
         ignore_bins ig1 = binsof(PTE_RWX_d.leaflvl_u);
         ignore_bins ig2 = binsof(mode.sv39) && binsof(misaligned_PPN_d.tera_not_zero);
     }
-    misaligned_write_u: cross PTE_RWX_d, misaligned_PPN_d, mode, store_page_fault, cbo_ins, priv_mode_u  {
+    misaligned_page_cbo_u: cross PTE_RWX_d, misaligned_PPN_d, mode, store_page_fault, cbo_ins, priv_mode_u  {
         ignore_bins ig1 = binsof(PTE_RWX_d.leaflvl_s);
         ignore_bins ig2 = binsof(mode.sv39) && binsof(misaligned_PPN_d.tera_not_zero);
     }
 
     // PTE points to a non existant physical address
-    leaf_PTE_to_nonexistant_pa_s: cross PTE_RWX_d, d_phys_address_nonexistant, PageType_d, mode, store_acc_fault, cbo_ins, priv_mode_s {
+    leaf_PTE_to_nonexistant_pa_cbo_s: cross PTE_RWX_d, d_phys_address_nonexistant, PageType_d, mode, store_acc_fault, cbo_ins, priv_mode_s {
         ignore_bins ig1 = binsof(PTE_RWX_d.leaflvl_u);
         ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
-    leaf_PTE_to_nonexistant_pa_u: cross PTE_RWX_d, d_phys_address_nonexistant, PageType_d, mode, store_acc_fault, cbo_ins, priv_mode_u {
+    leaf_PTE_to_nonexistant_pa_cbo_u: cross PTE_RWX_d, d_phys_address_nonexistant, PageType_d, mode, store_acc_fault, cbo_ins, priv_mode_u {
         ignore_bins ig1 = binsof(PTE_RWX_d.leaflvl_s);
         ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }
 
     // Non leaf PTE points to a non existatant phys addr instead of next page table. Store access fault required during walk
     // Example: Setup a giga page in sv48, lvl 3 pte (tera) should point to lvl2 page table, but it points to non existant PA
-    nonleaf_PTE_to_nonexistant_pa: cross pointer_PTE_d, d_phys_address_nonexistant, PageType_d, mode, store_acc_fault, cbo_ins, priv_mode_su {
+    nonleaf_PTE_to_nonexistant_pa_cbo: cross pointer_PTE_d, d_phys_address_nonexistant, PageType_d, mode, store_acc_fault, cbo_ins, priv_mode_su {
         ignore_bins ig1 = binsof(PageType_d.tera);                          // Here PageType_d will be the type being pointed towards
         ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.giga);
     }
 
-    PTE_nonleaf_DAU: cross PTE_DAU_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_su {
+    PTE_nonleaf_DAU_cbo: cross PTE_DAU_d, PageType_d, mode, store_page_fault, cbo_ins, priv_mode_su {
         ignore_bins ig1 = binsof(PageType_d.kilo);
         ignore_bins ig2 = binsof(mode.sv39) && binsof(PageType_d.tera);
     }


### PR DESCRIPTION
I have added new coverpoints for cbo.zero to VM_CBO. We have a coverpoint for Zicbom where R=1 and W=0 and it's not supposed to fault. As discussed in our previous meeting, I have added a new coverpoint where R=0, W=0 & X=1 which is supposed to fault.
I have updated the names of coverpoints. They had write in them, which I think should be changed because write might confuse someone in thinking that it's either the permission of PTE or we're using some store instruction. I have updated it to cbo, zicbom & zicboz respectively (where cbo represents both zicbom & zicboz). 
Some coverpoints for Zicboz are different from Zicboz such as
* D bit unset is supposed to fault for Zicboz while not for Zicbom
* Zicbom instructions will fault when (R=0 & W=0) and not when (R=1 & W=0).
* While zicboz will fault whenever W=0 (irrespective of R).

I have also rearranged some coverpoints, therefore the file difference for the PR might seem strange.
I have not made the changes for RV32 as I'll combine RV32 and 64 into this file. I will also update the testplan accordingly when these changes are approved.
